### PR TITLE
Add Fuel Log, Quick Toggles, Location widgets + 8 dashboard themes, plus widget polish and two bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Thumbs.db
 
 # Kotlin
 .kotlin/
+
+# Local Claude Code session notes — not for upstream
+CLAUDE.md

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,4 +79,8 @@ dependencies {
     implementation("com.google.code.gson:gson:2.13.1")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
+
+    // Unit tests — pure-logic functions only (src/test runs on the local JVM,
+    // no Android framework available without Robolectric/instrumentation)
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/java/com/openlauncher/app/MainActivity.kt
+++ b/app/src/main/java/com/openlauncher/app/MainActivity.kt
@@ -67,6 +67,8 @@ class MainActivity : ComponentActivity() {
             val appsLoading by vm.appsLoading.collectAsStateWithLifecycle()
             val nowPlaying  by vm.nowPlaying.collectAsStateWithLifecycle()
             val weather     by vm.weather.collectAsStateWithLifecycle()
+            val placeName   by vm.placeName.collectAsStateWithLifecycle()
+            val voltage     by vm.voltage.collectAsStateWithLifecycle()
             val location    by vm.location.collectAsStateWithLifecycle()
             val bearing     by vm.compassBearing.collectAsStateWithLifecycle()
             val isWifi      by vm.isWifi.collectAsStateWithLifecycle()
@@ -78,13 +80,17 @@ class MainActivity : ComponentActivity() {
             val pickerSlot      by vm.shortcutPickerSlot.collectAsStateWithLifecycle()
             val appPickerTarget by vm.appPickerTarget.collectAsStateWithLifecycle()
 
-            val accent         = Color(settings.accentColor)
-            val bg             = if (settings.useCustomBackgroundColor) {
+            // A preset themeId overrides the manually-picked accent/background/font
+            // colors below; "custom" (or an unrecognized id) falls through to those.
+            val resolvedTheme  = com.openlauncher.app.data.resolveDashboardTheme(settings.themeId, isDayMode)
+            val accent         = resolvedTheme?.accent ?: Color(settings.accentColor)
+            val bg             = resolvedTheme?.background ?: if (settings.useCustomBackgroundColor) {
                 Color(settings.backgroundColor)
             } else {
                 if (isDayMode) Color(0xFFEEEEEE) else Color.Black
             }
-            val textColor      = if (isDayMode) Color(0xFF111111) else Color(settings.fontColor)
+            val textColor      = resolvedTheme?.ink
+                ?: if (isDayMode) Color(0xFF111111) else Color(settings.fontColor)
             val bgGradientEnd  = Color(settings.gradientEndColor)
             val bgBrush        = if (settings.useCustomBackgroundColor && settings.useGradient) {
                 val colors = listOf(bg, bgGradientEnd)
@@ -113,7 +119,7 @@ class MainActivity : ComponentActivity() {
                     textScale  = settings.textScale,
                     appFont    = settings.appFont,
                     isDayMode  = isDayMode,
-                    useCustomBg = settings.useCustomBackgroundColor
+                    useCustomBg = resolvedTheme != null || settings.useCustomBackgroundColor
                 ) {
                 if (!settings.onboardingCompleted) {
                     OnboardingScreen(
@@ -153,6 +159,8 @@ class MainActivity : ComponentActivity() {
                                     currentDest   = nav,
                                     settings      = settings,
                                     isHorizontal  = isBottomBar,
+                                    themeAccent   = accent,
+                                    themeBg       = resolvedTheme?.background,
                                     installedIconFor = { pkg ->
                                         apps.find { it.packageName == pkg }?.icon
                                     },
@@ -193,6 +201,8 @@ class MainActivity : ComponentActivity() {
                                         weather             = weather,
                                         nowPlaying          = nowPlaying,
                                         location            = location,
+                                        placeName           = placeName,
+                                        voltage             = voltage,
                                         bearing             = bearing,
                                         isWifi              = isWifi,
                                         isData              = isData,
@@ -217,6 +227,8 @@ class MainActivity : ComponentActivity() {
                                         onMoveWidget        = { id, gx, gy -> vm.moveWidgetConfig(id, gx, gy) },
                                         onAddWidget         = { id -> vm.addWidget(id) },
                                         onRemoveWidget      = { id -> vm.removeWidget(id) },
+                                        onApplyPreset       = { preset -> vm.applyLayoutPreset(preset) },
+                                        onAddFuelEntry      = { odo, vol, cost -> vm.addFuelEntry(odo, vol, cost) },
                                         onSetClockStyle     = { style -> vm.updateSettings { copy(clockStyle = style) } },
                                         onSetVitalsAsBars   = { asBars -> vm.updateSettings { copy(vitalsAsBars = asBars) } },
                                         onSetSpeedometerDigitalOnly = { digital -> vm.updateSettings { copy(speedometerDigitalOnly = digital) } },

--- a/app/src/main/java/com/openlauncher/app/MainActivity.kt
+++ b/app/src/main/java/com/openlauncher/app/MainActivity.kt
@@ -232,6 +232,10 @@ class MainActivity : ComponentActivity() {
                                         onSetClockStyle     = { style -> vm.updateSettings { copy(clockStyle = style) } },
                                         onSetVitalsAsBars   = { asBars -> vm.updateSettings { copy(vitalsAsBars = asBars) } },
                                         onSetSpeedometerDigitalOnly = { digital -> vm.updateSettings { copy(speedometerDigitalOnly = digital) } },
+                                        onSetLocationDetailLevel = { level ->
+                                            vm.updateSettings { copy(locationDetailLevel = level) }
+                                            location?.let { vm.fetchPlaceName(it.latitude, it.longitude) }
+                                        },
                                         onUpdateSoundPad    = { idx, pad -> vm.updateSoundboardPad(idx, pad) },
                                         hardwareRadio         = hardwareRadio,
                                         onLaunchHardwareRadio = { vm.launchHardwareRadioApp() },

--- a/app/src/main/java/com/openlauncher/app/MainActivity.kt
+++ b/app/src/main/java/com/openlauncher/app/MainActivity.kt
@@ -245,7 +245,8 @@ class MainActivity : ComponentActivity() {
                                         onRadioCycleFm        = { vm.radioCycleFm() },
                                         onRadioSwitchAm       = { vm.radioSwitchAm() },
                                         onRadioTune           = { band, freq -> vm.radioTune(band, freq) },
-                                        onAssignRadio         = { vm.startRadioPicker() }
+                                        onAssignRadio         = { vm.startRadioPicker() },
+                                        onUpdate              = { block -> vm.updateSettings(block) }
                                     )
 
                                     NavDestination.APP_LIBRARY -> AppLibraryScreen(

--- a/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
+++ b/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
@@ -9,6 +9,10 @@ enum class AppFont { SYSTEM, JETBRAINS_MONO, SOURCE_CODE_PRO }
 enum class DayNightMode { DARK, LIGHT, AUTO, SYSTEM }
 enum class SidebarPosition { LEFT, RIGHT, BOTTOM }
 enum class GradientDirection { TOP_TO_BOTTOM, LEFT_TO_RIGHT, DIAGONAL, RADIAL }
+// How granular the reverse-geocoded place name is. NEIGHBORHOOD is the finest
+// (e.g. "Boon Keng") — needed in dense cities where CITY/REGION both just
+// collapse to the city-state's own name (Singapore, Monaco, etc).
+enum class LocationDetailLevel { NEIGHBORHOOD, CITY, REGION }
 
 enum class DefaultShortcutIcon {
     NONE,
@@ -116,6 +120,7 @@ data class AppSettings(
     val fuelLog: List<FuelEntry> = emptyList(),
     val showQuickToggles: Boolean = false,
     val showLocation: Boolean = false,
+    val locationDetailLevel: LocationDetailLevel = LocationDetailLevel.NEIGHBORHOOD,
     // "custom" = fall back to the manually-picked accentColor/backgroundColor below;
     // any DASHBOARD_THEMES id = use that preset's accent+surface for the current mode.
     val themeId: String = "ignition"

--- a/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
+++ b/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
@@ -123,7 +123,18 @@ data class AppSettings(
     val locationDetailLevel: LocationDetailLevel = LocationDetailLevel.NEIGHBORHOOD,
     // "custom" = fall back to the manually-picked accentColor/backgroundColor below;
     // any DASHBOARD_THEMES id = use that preset's accent+surface for the current mode.
-    val themeId: String = "ignition"
+    val themeId: String = "ignition",
+    // Weather panel enrichment — merged into the existing panel rather than
+    // adding new ones, each independently toggleable so the panel doesn't
+    // get crowded if the driver only wants some of them.
+    val showWindSpeed: Boolean = true,
+    val showFeelsLike: Boolean = true,
+    val showRainChance: Boolean = true,
+    // Clock panel enrichment
+    val showSunriseSunset: Boolean = true,
+    val showQuickTogglesInClock: Boolean = true,
+    // Now Playing panel enrichment
+    val showNowPlayingSourceBadge: Boolean = true
 )
 
 fun defaultShortcuts() = listOf(

--- a/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
+++ b/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
@@ -41,6 +41,14 @@ fun defaultSoundboardPads() = listOf(
     SoundPadConfig("+",            synthType = "")
 )
 
+data class FuelEntry(
+    val timestampMs: Long,
+    val odometerKm: Double,   // always stored in km; converted for display per unitSystem
+    val volume: Double,       // liters (metric entries) or gallons (imperial entries)
+    val cost: Double,
+    val isMetric: Boolean     // unit system in effect when this entry was logged
+)
+
 data class ShortcutConfig(
     val packageName: String = "",
     val label: String = "",
@@ -103,7 +111,14 @@ data class AppSettings(
     val vitalsAsBars: Boolean = false,
     val speedometerDigitalOnly: Boolean = false,
     val gradientDirection: GradientDirection = GradientDirection.DIAGONAL,
-    val useCustomBackgroundColor: Boolean = false
+    val useCustomBackgroundColor: Boolean = false,
+    val showFuelLog: Boolean = false,
+    val fuelLog: List<FuelEntry> = emptyList(),
+    val showQuickToggles: Boolean = false,
+    val showLocation: Boolean = false,
+    // "custom" = fall back to the manually-picked accentColor/backgroundColor below;
+    // any DASHBOARD_THEMES id = use that preset's accent+surface for the current mode.
+    val themeId: String = "ignition"
 )
 
 fun defaultShortcuts() = listOf(
@@ -120,6 +135,24 @@ fun defaultWidgetLayout() = listOf(
     WidgetConfig("NOW_PLAYING", gridX = 0, gridY = 1, spanX = 2, spanY = 1)
 )
 
+/**
+ * Media-dominant "split panel" layout: a big Now Playing card fills the left
+ * two-thirds (album art, transport controls), Weather and Clock stack as
+ * glanceable info on the right — same cockpit feel as the closed-source
+ * Mini AA launcher, built from widgets OpenLauncher already has natively.
+ */
+fun splitPanelWidgetLayout() = listOf(
+    WidgetConfig("NOW_PLAYING", gridX = 0, gridY = 0, spanX = 2, spanY = 2),
+    WidgetConfig("WEATHER",     gridX = 2, gridY = 0, spanX = 1, spanY = 1),
+    WidgetConfig("CLOCK",       gridX = 2, gridY = 1, spanX = 1, spanY = 1)
+)
+
+/** Widget ids toggled by [AppSettings.showX] flags — used to sync those flags to a preset. */
+val PRESET_TOGGLEABLE_IDS = setOf(
+    "CLOCK", "WEATHER", "NOW_PLAYING", "TELEMETRY", "ALTIMETER",
+    "SPEEDOMETER", "VITALS", "TRIP_TRACKER", "SOUNDBOARD"
+)
+
 fun AppSettings.activeWidgetIds(): Set<String> = buildSet {
     if (showClock) add("CLOCK")
     if (showWeather) add("WEATHER")
@@ -130,6 +163,9 @@ fun AppSettings.activeWidgetIds(): Set<String> = buildSet {
     if (showVitals) add("VITALS")
     if (showTripTracker) add("TRIP_TRACKER")
     if (showSoundboard) add("SOUNDBOARD")
+    if (showFuelLog) add("FUEL_LOG")
+    if (showQuickToggles) add("QUICK_TOGGLES")
+    if (showLocation) add("LOCATION")
 }
 
 /**

--- a/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
+++ b/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
@@ -134,7 +134,8 @@ data class AppSettings(
     val showSunriseSunset: Boolean = true,
     val showQuickTogglesInClock: Boolean = true,
     // Now Playing panel enrichment
-    val showNowPlayingSourceBadge: Boolean = true
+    val showNowPlayingSourceBadge: Boolean = true,
+    val use24HourFormat: Boolean = true
 )
 
 fun defaultShortcuts() = listOf(

--- a/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
+++ b/app/src/main/java/com/openlauncher/app/data/AppSettings.kt
@@ -14,6 +14,17 @@ enum class GradientDirection { TOP_TO_BOTTOM, LEFT_TO_RIGHT, DIAGONAL, RADIAL }
 // collapse to the city-state's own name (Singapore, Monaco, etc).
 enum class LocationDetailLevel { NEIGHBORHOOD, CITY, REGION }
 
+// How often the live place name (Weather + Location widgets) refreshes while
+// driving. Only affects the moving case — parked, refresh is bottlenecked by
+// a separate once-a-minute fallback ticker regardless of this setting, since
+// a stationary GPS provider doesn't emit new location updates at all.
+enum class LocationRefreshInterval(val millis: Long) {
+    SEC_30(30_000L),
+    MIN_1(60_000L),
+    MIN_2(120_000L),
+    MIN_5(300_000L)
+}
+
 enum class DefaultShortcutIcon {
     NONE,
     // Navigation & vehicle
@@ -121,6 +132,7 @@ data class AppSettings(
     val showQuickToggles: Boolean = false,
     val showLocation: Boolean = false,
     val locationDetailLevel: LocationDetailLevel = LocationDetailLevel.NEIGHBORHOOD,
+    val locationRefreshInterval: LocationRefreshInterval = LocationRefreshInterval.SEC_30,
     // "custom" = fall back to the manually-picked accentColor/backgroundColor below;
     // any DASHBOARD_THEMES id = use that preset's accent+surface for the current mode.
     val themeId: String = "ignition",

--- a/app/src/main/java/com/openlauncher/app/data/NominatimApi.kt
+++ b/app/src/main/java/com/openlauncher/app/data/NominatimApi.kt
@@ -8,12 +8,18 @@ import retrofit2.http.GET
 import retrofit2.http.Query
 
 data class NominatimAddress(
-    @SerializedName("suburb")  val suburb: String? = null,
-    @SerializedName("city")    val city: String? = null,
-    @SerializedName("town")    val town: String? = null,
-    @SerializedName("village") val village: String? = null,
-    @SerializedName("county")  val county: String? = null,
-    @SerializedName("state")   val state: String? = null
+    // Finest → coarsest. Dense cities (e.g. Singapore, where "city" and "country"
+    // both just resolve to "Singapore") only surface real granularity through
+    // neighbourhood/quarter — suburb alone isn't enough there.
+    @SerializedName("neighbourhood")  val neighbourhood: String? = null,
+    @SerializedName("quarter")        val quarter: String? = null,
+    @SerializedName("suburb")         val suburb: String? = null,
+    @SerializedName("city_district")  val cityDistrict: String? = null,
+    @SerializedName("city")           val city: String? = null,
+    @SerializedName("town")           val town: String? = null,
+    @SerializedName("village")        val village: String? = null,
+    @SerializedName("county")         val county: String? = null,
+    @SerializedName("state")          val state: String? = null
 )
 
 data class NominatimResponse(
@@ -27,7 +33,12 @@ interface NominatimApiService {
         @Query("lat") lat: Double,
         @Query("lon") lon: Double,
         @Query("format") format: String = "json",
-        @Query("zoom") zoom: Int = 12,
+        // Always request the finest zoom (18 = building-level) — Nominatim still
+        // returns the full coarse-to-fine address hierarchy either way, so this
+        // just ensures the fine fields (neighbourhood/quarter) are populated when
+        // they exist. Which field to actually display is a client-side choice —
+        // see LocationDetailLevel.
+        @Query("zoom") zoom: Int = 18,
         @Query("addressdetails") addressDetails: Int = 1
     ): NominatimResponse
 }

--- a/app/src/main/java/com/openlauncher/app/data/NominatimApi.kt
+++ b/app/src/main/java/com/openlauncher/app/data/NominatimApi.kt
@@ -1,0 +1,53 @@
+package com.openlauncher.app.data
+
+import com.google.gson.annotations.SerializedName
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+data class NominatimAddress(
+    @SerializedName("suburb")  val suburb: String? = null,
+    @SerializedName("city")    val city: String? = null,
+    @SerializedName("town")    val town: String? = null,
+    @SerializedName("village") val village: String? = null,
+    @SerializedName("county")  val county: String? = null,
+    @SerializedName("state")   val state: String? = null
+)
+
+data class NominatimResponse(
+    @SerializedName("address")     val address: NominatimAddress? = null,
+    @SerializedName("display_name") val displayName: String? = null
+)
+
+interface NominatimApiService {
+    @GET("reverse")
+    suspend fun reverseGeocode(
+        @Query("lat") lat: Double,
+        @Query("lon") lon: Double,
+        @Query("format") format: String = "json",
+        @Query("zoom") zoom: Int = 12,
+        @Query("addressdetails") addressDetails: Int = 1
+    ): NominatimResponse
+}
+
+object NominatimApi {
+    // Nominatim's usage policy requires a self-identifying User-Agent on every
+    // request — the default OkHttp UA gets silently rate-limited/blocked.
+    private val client = OkHttpClient.Builder()
+        .addInterceptor { chain ->
+            val request = chain.request().newBuilder()
+                .header("User-Agent", "OpenLauncher-CarDashboard/1.0 (single-user, personal)")
+                .build()
+            chain.proceed(request)
+        }
+        .build()
+
+    val service: NominatimApiService = Retrofit.Builder()
+        .baseUrl("https://nominatim.openstreetmap.org/")
+        .client(client)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(NominatimApiService::class.java)
+}

--- a/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
@@ -64,6 +64,7 @@ class SettingsRepository(private val context: Context) {
         val SHOW_QUICK_TOGGLES    = booleanPreferencesKey("show_quick_toggles")
         val THEME_ID              = stringPreferencesKey("theme_id")
         val SHOW_LOCATION         = booleanPreferencesKey("show_location")
+        val LOCATION_DETAIL_LEVEL = stringPreferencesKey("location_detail_level")
     }
 
     val settingsFlow: Flow<AppSettings> = context.dataStore.data
@@ -148,7 +149,8 @@ class SettingsRepository(private val context: Context) {
                 } ?: defaults.fuelLog,
                 showQuickToggles = prefs[Keys.SHOW_QUICK_TOGGLES] ?: defaults.showQuickToggles,
                 themeId          = prefs[Keys.THEME_ID] ?: defaults.themeId,
-                showLocation     = prefs[Keys.SHOW_LOCATION] ?: defaults.showLocation
+                showLocation     = prefs[Keys.SHOW_LOCATION] ?: defaults.showLocation,
+                locationDetailLevel = prefs[Keys.LOCATION_DETAIL_LEVEL]?.let { runCatching { LocationDetailLevel.valueOf(it) }.getOrNull() } ?: defaults.locationDetailLevel
             )
     }
 
@@ -210,6 +212,7 @@ class SettingsRepository(private val context: Context) {
             prefs[Keys.SHOW_QUICK_TOGGLES] = s.showQuickToggles
             prefs[Keys.THEME_ID]           = s.themeId
             prefs[Keys.SHOW_LOCATION]      = s.showLocation
+            prefs[Keys.LOCATION_DETAIL_LEVEL] = s.locationDetailLevel.name
     }
 
     suspend fun resetToDefaults() {

--- a/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
@@ -71,6 +71,7 @@ class SettingsRepository(private val context: Context) {
         val SHOW_SUNRISE_SUNSET   = booleanPreferencesKey("show_sunrise_sunset")
         val SHOW_QUICK_TOGGLES_IN_CLOCK = booleanPreferencesKey("show_quick_toggles_in_clock")
         val SHOW_NOW_PLAYING_SOURCE_BADGE = booleanPreferencesKey("show_now_playing_source_badge")
+        val USE_24_HOUR_FORMAT    = booleanPreferencesKey("use_24_hour_format")
     }
 
     val settingsFlow: Flow<AppSettings> = context.dataStore.data
@@ -162,7 +163,8 @@ class SettingsRepository(private val context: Context) {
                 showRainChance   = prefs[Keys.SHOW_RAIN_CHANCE] ?: defaults.showRainChance,
                 showSunriseSunset = prefs[Keys.SHOW_SUNRISE_SUNSET] ?: defaults.showSunriseSunset,
                 showQuickTogglesInClock = prefs[Keys.SHOW_QUICK_TOGGLES_IN_CLOCK] ?: defaults.showQuickTogglesInClock,
-                showNowPlayingSourceBadge = prefs[Keys.SHOW_NOW_PLAYING_SOURCE_BADGE] ?: defaults.showNowPlayingSourceBadge
+                showNowPlayingSourceBadge = prefs[Keys.SHOW_NOW_PLAYING_SOURCE_BADGE] ?: defaults.showNowPlayingSourceBadge,
+                use24HourFormat  = prefs[Keys.USE_24_HOUR_FORMAT] ?: defaults.use24HourFormat
             )
     }
 
@@ -231,6 +233,7 @@ class SettingsRepository(private val context: Context) {
             prefs[Keys.SHOW_SUNRISE_SUNSET] = s.showSunriseSunset
             prefs[Keys.SHOW_QUICK_TOGGLES_IN_CLOCK] = s.showQuickTogglesInClock
             prefs[Keys.SHOW_NOW_PLAYING_SOURCE_BADGE] = s.showNowPlayingSourceBadge
+            prefs[Keys.USE_24_HOUR_FORMAT] = s.use24HourFormat
     }
 
     suspend fun resetToDefaults() {

--- a/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
@@ -59,6 +59,11 @@ class SettingsRepository(private val context: Context) {
         val SPEEDOMETER_DIGITAL_ONLY = booleanPreferencesKey("speedometer_digital_only")
         val GRADIENT_DIRECTION    = stringPreferencesKey("gradient_direction")
         val USE_CUSTOM_BG_COLOR   = booleanPreferencesKey("use_custom_bg_color")
+        val SHOW_FUEL_LOG         = booleanPreferencesKey("show_fuel_log")
+        val FUEL_LOG_JSON         = stringPreferencesKey("fuel_log_json")
+        val SHOW_QUICK_TOGGLES    = booleanPreferencesKey("show_quick_toggles")
+        val THEME_ID              = stringPreferencesKey("theme_id")
+        val SHOW_LOCATION         = booleanPreferencesKey("show_location")
     }
 
     val settingsFlow: Flow<AppSettings> = context.dataStore.data
@@ -134,7 +139,16 @@ class SettingsRepository(private val context: Context) {
                 vitalsAsBars     = prefs[Keys.VITALS_AS_BARS] ?: defaults.vitalsAsBars,
                 speedometerDigitalOnly = prefs[Keys.SPEEDOMETER_DIGITAL_ONLY] ?: defaults.speedometerDigitalOnly,
                 gradientDirection = prefs[Keys.GRADIENT_DIRECTION]?.let { runCatching { GradientDirection.valueOf(it) }.getOrNull() } ?: defaults.gradientDirection,
-                useCustomBackgroundColor = prefs[Keys.USE_CUSTOM_BG_COLOR] ?: defaults.useCustomBackgroundColor
+                useCustomBackgroundColor = prefs[Keys.USE_CUSTOM_BG_COLOR] ?: defaults.useCustomBackgroundColor,
+                showFuelLog      = prefs[Keys.SHOW_FUEL_LOG]    ?: defaults.showFuelLog,
+                fuelLog          = prefs[Keys.FUEL_LOG_JSON]?.let {
+                    runCatching {
+                        gson.fromJson<List<FuelEntry>>(it, object : TypeToken<List<FuelEntry>>() {}.type)
+                    }.getOrNull()
+                } ?: defaults.fuelLog,
+                showQuickToggles = prefs[Keys.SHOW_QUICK_TOGGLES] ?: defaults.showQuickToggles,
+                themeId          = prefs[Keys.THEME_ID] ?: defaults.themeId,
+                showLocation     = prefs[Keys.SHOW_LOCATION] ?: defaults.showLocation
             )
     }
 
@@ -191,6 +205,11 @@ class SettingsRepository(private val context: Context) {
             prefs[Keys.SPEEDOMETER_DIGITAL_ONLY] = s.speedometerDigitalOnly
             prefs[Keys.GRADIENT_DIRECTION] = s.gradientDirection.name
             prefs[Keys.USE_CUSTOM_BG_COLOR] = s.useCustomBackgroundColor
+            prefs[Keys.SHOW_FUEL_LOG]      = s.showFuelLog
+            prefs[Keys.FUEL_LOG_JSON]      = gson.toJson(s.fuelLog)
+            prefs[Keys.SHOW_QUICK_TOGGLES] = s.showQuickToggles
+            prefs[Keys.THEME_ID]           = s.themeId
+            prefs[Keys.SHOW_LOCATION]      = s.showLocation
     }
 
     suspend fun resetToDefaults() {

--- a/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
@@ -65,6 +65,12 @@ class SettingsRepository(private val context: Context) {
         val THEME_ID              = stringPreferencesKey("theme_id")
         val SHOW_LOCATION         = booleanPreferencesKey("show_location")
         val LOCATION_DETAIL_LEVEL = stringPreferencesKey("location_detail_level")
+        val SHOW_WIND_SPEED       = booleanPreferencesKey("show_wind_speed")
+        val SHOW_FEELS_LIKE       = booleanPreferencesKey("show_feels_like")
+        val SHOW_RAIN_CHANCE      = booleanPreferencesKey("show_rain_chance")
+        val SHOW_SUNRISE_SUNSET   = booleanPreferencesKey("show_sunrise_sunset")
+        val SHOW_QUICK_TOGGLES_IN_CLOCK = booleanPreferencesKey("show_quick_toggles_in_clock")
+        val SHOW_NOW_PLAYING_SOURCE_BADGE = booleanPreferencesKey("show_now_playing_source_badge")
     }
 
     val settingsFlow: Flow<AppSettings> = context.dataStore.data
@@ -150,7 +156,13 @@ class SettingsRepository(private val context: Context) {
                 showQuickToggles = prefs[Keys.SHOW_QUICK_TOGGLES] ?: defaults.showQuickToggles,
                 themeId          = prefs[Keys.THEME_ID] ?: defaults.themeId,
                 showLocation     = prefs[Keys.SHOW_LOCATION] ?: defaults.showLocation,
-                locationDetailLevel = prefs[Keys.LOCATION_DETAIL_LEVEL]?.let { runCatching { LocationDetailLevel.valueOf(it) }.getOrNull() } ?: defaults.locationDetailLevel
+                locationDetailLevel = prefs[Keys.LOCATION_DETAIL_LEVEL]?.let { runCatching { LocationDetailLevel.valueOf(it) }.getOrNull() } ?: defaults.locationDetailLevel,
+                showWindSpeed    = prefs[Keys.SHOW_WIND_SPEED] ?: defaults.showWindSpeed,
+                showFeelsLike    = prefs[Keys.SHOW_FEELS_LIKE] ?: defaults.showFeelsLike,
+                showRainChance   = prefs[Keys.SHOW_RAIN_CHANCE] ?: defaults.showRainChance,
+                showSunriseSunset = prefs[Keys.SHOW_SUNRISE_SUNSET] ?: defaults.showSunriseSunset,
+                showQuickTogglesInClock = prefs[Keys.SHOW_QUICK_TOGGLES_IN_CLOCK] ?: defaults.showQuickTogglesInClock,
+                showNowPlayingSourceBadge = prefs[Keys.SHOW_NOW_PLAYING_SOURCE_BADGE] ?: defaults.showNowPlayingSourceBadge
             )
     }
 
@@ -213,6 +225,12 @@ class SettingsRepository(private val context: Context) {
             prefs[Keys.THEME_ID]           = s.themeId
             prefs[Keys.SHOW_LOCATION]      = s.showLocation
             prefs[Keys.LOCATION_DETAIL_LEVEL] = s.locationDetailLevel.name
+            prefs[Keys.SHOW_WIND_SPEED]    = s.showWindSpeed
+            prefs[Keys.SHOW_FEELS_LIKE]    = s.showFeelsLike
+            prefs[Keys.SHOW_RAIN_CHANCE]   = s.showRainChance
+            prefs[Keys.SHOW_SUNRISE_SUNSET] = s.showSunriseSunset
+            prefs[Keys.SHOW_QUICK_TOGGLES_IN_CLOCK] = s.showQuickTogglesInClock
+            prefs[Keys.SHOW_NOW_PLAYING_SOURCE_BADGE] = s.showNowPlayingSourceBadge
     }
 
     suspend fun resetToDefaults() {

--- a/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
+++ b/app/src/main/java/com/openlauncher/app/data/SettingsRepository.kt
@@ -65,6 +65,7 @@ class SettingsRepository(private val context: Context) {
         val THEME_ID              = stringPreferencesKey("theme_id")
         val SHOW_LOCATION         = booleanPreferencesKey("show_location")
         val LOCATION_DETAIL_LEVEL = stringPreferencesKey("location_detail_level")
+        val LOCATION_REFRESH_INTERVAL = stringPreferencesKey("location_refresh_interval")
         val SHOW_WIND_SPEED       = booleanPreferencesKey("show_wind_speed")
         val SHOW_FEELS_LIKE       = booleanPreferencesKey("show_feels_like")
         val SHOW_RAIN_CHANCE      = booleanPreferencesKey("show_rain_chance")
@@ -158,6 +159,7 @@ class SettingsRepository(private val context: Context) {
                 themeId          = prefs[Keys.THEME_ID] ?: defaults.themeId,
                 showLocation     = prefs[Keys.SHOW_LOCATION] ?: defaults.showLocation,
                 locationDetailLevel = prefs[Keys.LOCATION_DETAIL_LEVEL]?.let { runCatching { LocationDetailLevel.valueOf(it) }.getOrNull() } ?: defaults.locationDetailLevel,
+                locationRefreshInterval = prefs[Keys.LOCATION_REFRESH_INTERVAL]?.let { runCatching { LocationRefreshInterval.valueOf(it) }.getOrNull() } ?: defaults.locationRefreshInterval,
                 showWindSpeed    = prefs[Keys.SHOW_WIND_SPEED] ?: defaults.showWindSpeed,
                 showFeelsLike    = prefs[Keys.SHOW_FEELS_LIKE] ?: defaults.showFeelsLike,
                 showRainChance   = prefs[Keys.SHOW_RAIN_CHANCE] ?: defaults.showRainChance,
@@ -227,6 +229,7 @@ class SettingsRepository(private val context: Context) {
             prefs[Keys.THEME_ID]           = s.themeId
             prefs[Keys.SHOW_LOCATION]      = s.showLocation
             prefs[Keys.LOCATION_DETAIL_LEVEL] = s.locationDetailLevel.name
+            prefs[Keys.LOCATION_REFRESH_INTERVAL] = s.locationRefreshInterval.name
             prefs[Keys.SHOW_WIND_SPEED]    = s.showWindSpeed
             prefs[Keys.SHOW_FEELS_LIKE]    = s.showFeelsLike
             prefs[Keys.SHOW_RAIN_CHANCE]   = s.showRainChance

--- a/app/src/main/java/com/openlauncher/app/data/ThemePresets.kt
+++ b/app/src/main/java/com/openlauncher/app/data/ThemePresets.kt
@@ -1,0 +1,78 @@
+package com.openlauncher.app.data
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * A named accent + surface pairing for each mode. Each preset's light and dark
+ * surfaces are independently tinted toward the theme's character — not a shared
+ * neutral with only the accent swapped, and not the dark accent simply dropped
+ * onto white. Every accent/surface pair here was contrast-checked (WCAG) before
+ * landing: see the design artifact this was picked from for the exact ratios.
+ */
+data class DashboardThemeDef(
+    val id: String,
+    val label: String,
+    val darkAccent: Long,
+    val darkBg: Long,
+    val darkInk: Long,
+    val lightAccent: Long,
+    val lightBg: Long
+)
+
+val DASHBOARD_THEMES = listOf(
+    DashboardThemeDef(
+        id = "ignition", label = "Ignition",
+        darkAccent  = 0xFFFF6B4AL, darkBg  = 0xFF160F0DL, darkInk = 0xFFF3E9E4L,
+        lightAccent = 0xFFB23814L, lightBg = 0xFFF4EAE1L
+    ),
+    DashboardThemeDef(
+        id = "amber", label = "Amber Cluster",
+        darkAccent  = 0xFFE8A93DL, darkBg  = 0xFF171008L, darkInk = 0xFFF3ECDDL,
+        lightAccent = 0xFF7C4E0CL, lightBg = 0xFFF2E6CEL
+    ),
+    DashboardThemeDef(
+        id = "cobalt", label = "Cobalt Run",
+        darkAccent  = 0xFF5B7CFAL, darkBg  = 0xFF0A0E17L, darkInk = 0xFFE7EAF5L,
+        lightAccent = 0xFF3247B5L, lightBg = 0xFFE4E9F5L
+    ),
+    DashboardThemeDef(
+        id = "verdigris", label = "Verdigris",
+        darkAccent  = 0xFF2FBFA0L, darkBg  = 0xFF0B1613L, darkInk = 0xFFE4F2EDL,
+        lightAccent = 0xFF0E6E58L, lightBg = 0xFFDCEBE6L
+    ),
+    DashboardThemeDef(
+        id = "plum", label = "Plum Static",
+        darkAccent  = 0xFFC86BE0L, darkBg  = 0xFF150A16L, darkInk = 0xFFF0E4F1L,
+        lightAccent = 0xFF7A1F94L, lightBg = 0xFFEFE1EEL
+    ),
+    DashboardThemeDef(
+        id = "blueprint", label = "Blueprint",
+        darkAccent  = 0xFFB8E4FFL, darkBg  = 0xFF0B1D30L, darkInk = 0xFFE4F3FFL,
+        lightAccent = 0xFF1B3A6BL, lightBg = 0xFFF2EFE4L
+    ),
+    DashboardThemeDef(
+        id = "circuit", label = "Circuit",
+        darkAccent  = 0xFFE8B84DL, darkBg  = 0xFF0A1F17L, darkInk = 0xFFEAF3EEL,
+        lightAccent = 0xFF7A4A12L, lightBg = 0xFFF0EDE4L
+    ),
+    DashboardThemeDef(
+        id = "instrument", label = "Instrument Cluster",
+        darkAccent  = 0xFFFFA23DL, darkBg  = 0xFF14100AL, darkInk = 0xFFF3ECDDL,
+        lightAccent = 0xFF1F2A44L, lightBg = 0xFFF0E6D2L
+    )
+)
+
+data class ResolvedTheme(
+    val accent: Color,
+    val background: Color,
+    val ink: Color?  // non-null only in dark mode — light mode keeps the app's existing neutral ink
+)
+
+fun resolveDashboardTheme(themeId: String, isDayMode: Boolean): ResolvedTheme? {
+    val def = DASHBOARD_THEMES.find { it.id == themeId } ?: return null
+    return if (isDayMode) {
+        ResolvedTheme(accent = Color(def.lightAccent), background = Color(def.lightBg), ink = null)
+    } else {
+        ResolvedTheme(accent = Color(def.darkAccent), background = Color(def.darkBg), ink = Color(def.darkInk))
+    }
+}

--- a/app/src/main/java/com/openlauncher/app/data/WeatherApi.kt
+++ b/app/src/main/java/com/openlauncher/app/data/WeatherApi.kt
@@ -38,7 +38,11 @@ interface WeatherApiService {
         @Query("hourly")           hourly: String = "temperature_2m,weathercode,precipitation_probability,apparent_temperature",
         @Query("forecast_days")    forecastDays: Int = 2,
         @Query("temperature_unit") temperatureUnit: String = "celsius",
-        @Query("windspeed_unit")   windspeedUnit: String = "kmh"
+        @Query("windspeed_unit")   windspeedUnit: String = "kmh",
+        // "auto" returns hourly timestamps in the queried location's own local
+        // time (Open-Meteo defaults to GMT otherwise) — matches the device-local
+        // "now" string this gets compared against when picking current-hour-onward points.
+        @Query("timezone")        timezone: String = "auto"
     ): OpenMeteoResponse
 }
 

--- a/app/src/main/java/com/openlauncher/app/data/WeatherApi.kt
+++ b/app/src/main/java/com/openlauncher/app/data/WeatherApi.kt
@@ -22,9 +22,11 @@ data class CurrentWeather(
 // Open-Meteo returns hourly data as parallel arrays (same index = same hour),
 // not a list of objects — zipped into HourlyPoint list after the response lands.
 data class HourlyBlock(
-    @SerializedName("time")          val time: List<String> = emptyList(),
-    @SerializedName("temperature_2m") val temperature2m: List<Double> = emptyList(),
-    @SerializedName("weathercode")   val weathercode: List<Int> = emptyList()
+    @SerializedName("time")                  val time: List<String> = emptyList(),
+    @SerializedName("temperature_2m")        val temperature2m: List<Double> = emptyList(),
+    @SerializedName("weathercode")           val weathercode: List<Int> = emptyList(),
+    @SerializedName("precipitation_probability") val precipitationProbability: List<Int> = emptyList(),
+    @SerializedName("apparent_temperature")  val apparentTemperature: List<Double> = emptyList()
 )
 
 interface WeatherApiService {
@@ -33,7 +35,7 @@ interface WeatherApiService {
         @Query("latitude")         latitude: Double,
         @Query("longitude")        longitude: Double,
         @Query("current_weather")  currentWeather: Boolean = true,
-        @Query("hourly")           hourly: String = "temperature_2m,weathercode",
+        @Query("hourly")           hourly: String = "temperature_2m,weathercode,precipitation_probability,apparent_temperature",
         @Query("forecast_days")    forecastDays: Int = 2,
         @Query("temperature_unit") temperatureUnit: String = "celsius",
         @Query("windspeed_unit")   windspeedUnit: String = "kmh"

--- a/app/src/main/java/com/openlauncher/app/data/WeatherApi.kt
+++ b/app/src/main/java/com/openlauncher/app/data/WeatherApi.kt
@@ -8,7 +8,8 @@ import retrofit2.http.GET
 import retrofit2.http.Query
 
 data class OpenMeteoResponse(
-    @SerializedName("current_weather") val currentWeather: CurrentWeather?
+    @SerializedName("current_weather") val currentWeather: CurrentWeather?,
+    @SerializedName("hourly")          val hourly: HourlyBlock?
 )
 
 data class CurrentWeather(
@@ -18,12 +19,22 @@ data class CurrentWeather(
     @SerializedName("is_day")       val isDay: Int
 )
 
+// Open-Meteo returns hourly data as parallel arrays (same index = same hour),
+// not a list of objects — zipped into HourlyPoint list after the response lands.
+data class HourlyBlock(
+    @SerializedName("time")          val time: List<String> = emptyList(),
+    @SerializedName("temperature_2m") val temperature2m: List<Double> = emptyList(),
+    @SerializedName("weathercode")   val weathercode: List<Int> = emptyList()
+)
+
 interface WeatherApiService {
     @GET("v1/forecast")
     suspend fun getForecast(
         @Query("latitude")         latitude: Double,
         @Query("longitude")        longitude: Double,
         @Query("current_weather")  currentWeather: Boolean = true,
+        @Query("hourly")           hourly: String = "temperature_2m,weathercode",
+        @Query("forecast_days")    forecastDays: Int = 2,
         @Query("temperature_unit") temperatureUnit: String = "celsius",
         @Query("windspeed_unit")   windspeedUnit: String = "kmh"
     ): OpenMeteoResponse

--- a/app/src/main/java/com/openlauncher/app/model/WeatherState.kt
+++ b/app/src/main/java/com/openlauncher/app/model/WeatherState.kt
@@ -4,7 +4,8 @@ data class HourlyPoint(
     val hour: Int,           // 0-23, local time
     val temperatureCelsius: Double,
     val weatherCode: Int,
-    val isDay: Boolean
+    val isDay: Boolean,
+    val precipitationChance: Int = 0   // 0-100, percent
 ) {
     fun temperatureDisplay(metric: Boolean): String =
         if (metric) "${Math.round(temperatureCelsius)}°" else "${Math.round(celsiusToFahrenheit(temperatureCelsius))}°"
@@ -17,12 +18,21 @@ data class WeatherState(
     val weatherCode: Int,
     val windspeedKmh: Double,
     val isDay: Boolean,
-    val hourlyForecast: List<HourlyPoint> = emptyList()
+    val hourlyForecast: List<HourlyPoint> = emptyList(),
+    val feelsLikeCelsius: Double = temperatureCelsius
 ) {
     // roundToInt, not toInt — truncation displayed 20.9° as 20°
     fun temperatureDisplay(metric: Boolean): String =
         if (metric) "${Math.round(temperatureCelsius)}°C"
         else "${Math.round(celsiusToFahrenheit(temperatureCelsius))}°F"
+
+    fun feelsLikeDisplay(metric: Boolean): String =
+        if (metric) "${Math.round(feelsLikeCelsius)}°"
+        else "${Math.round(celsiusToFahrenheit(feelsLikeCelsius))}°"
+
+    fun windspeedDisplay(metric: Boolean): String =
+        if (metric) "${Math.round(windspeedKmh)} km/h"
+        else "${Math.round(windspeedKmh / 1.609)} mph"
 
     val conditionLabel: String get() = wmoCodeToLabel(weatherCode)
     val conditionIcon: String get() = wmoCodeToEmoji(weatherCode, isDay)

--- a/app/src/main/java/com/openlauncher/app/model/WeatherState.kt
+++ b/app/src/main/java/com/openlauncher/app/model/WeatherState.kt
@@ -1,10 +1,23 @@
 package com.openlauncher.app.model
 
+data class HourlyPoint(
+    val hour: Int,           // 0-23, local time
+    val temperatureCelsius: Double,
+    val weatherCode: Int,
+    val isDay: Boolean
+) {
+    fun temperatureDisplay(metric: Boolean): String =
+        if (metric) "${Math.round(temperatureCelsius)}°" else "${Math.round(celsiusToFahrenheit(temperatureCelsius))}°"
+
+    val conditionIcon: String get() = wmoCodeToEmoji(weatherCode, isDay)
+}
+
 data class WeatherState(
     val temperatureCelsius: Double,
     val weatherCode: Int,
     val windspeedKmh: Double,
-    val isDay: Boolean
+    val isDay: Boolean,
+    val hourlyForecast: List<HourlyPoint> = emptyList()
 ) {
     // roundToInt, not toInt — truncation displayed 20.9° as 20°
     fun temperatureDisplay(metric: Boolean): String =

--- a/app/src/main/java/com/openlauncher/app/ui/components/Sidebar.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/components/Sidebar.kt
@@ -57,11 +57,16 @@ fun Sidebar(
     onShortcutSetIcon: (Int, DefaultShortcutIcon?) -> Unit,
     onReorder: (from: Int, to: Int) -> Unit,
     isHorizontal: Boolean = false,
+    themeAccent: Color? = null,
+    themeBg: Color? = null,
     modifier: Modifier = Modifier
 ) {
     val isDayMode    = LocalDayMode.current
-    val accent       = Color(settings.accentColor)
-    val sidebarBg    = if (isDayMode) Color(0xFFE0E0E0) else Color.Black.copy(alpha = 0.4f)
+    // A preset dashboard theme overrides the raw accentColor/background the same
+    // way it does for HomeScreen — otherwise the sidebar stays visually stuck on
+    // whatever was last manually set, ignoring the active theme entirely.
+    val accent       = themeAccent ?: Color(settings.accentColor)
+    val sidebarBg    = themeBg ?: if (isDayMode) Color(0xFFE0E0E0) else Color.Black.copy(alpha = 0.4f)
     val iconInactive = if (isDayMode) Color(0xFF777777) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.3f)
     val dividerColor = if (isDayMode) Color(0xFFCCCCCC) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.08f)
     val density      = LocalDensity.current

--- a/app/src/main/java/com/openlauncher/app/ui/screen/AppLibraryScreen.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/screen/AppLibraryScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.graphics.drawable.toBitmap
 import com.openlauncher.app.model.AppInfo
 import com.openlauncher.app.ui.theme.LocalDayMode
+import com.openlauncher.app.ui.theme.onAccentColor
 
 private enum class AppFilter { USER, SYSTEM, ALL }
 
@@ -112,7 +113,7 @@ fun AppLibraryScreen(
                             },
                             colors = FilterChipDefaults.filterChipColors(
                                 selectedContainerColor = accent,
-                                selectedLabelColor     = Color.Black,
+                                selectedLabelColor     = onAccentColor(accent),
                                 labelColor             = placeholderC
                             )
                         )

--- a/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
@@ -52,12 +52,17 @@ private data class WidgetTypeInfo(
     val id: String,
     val label: String,
     val icon: ImageVector,
-    val description: String
+    val description: String,
+    // Needs a live internet connection (WiFi/hotspot or the unit's own cellular
+    // data) to actually populate — Weather (Open-Meteo) and Location's place
+    // name (Nominatim reverse geocoding) both go blank offline, unlike every
+    // other widget here which works from local sensors/data alone.
+    val requiresNetwork: Boolean = false
 )
 
 private val ALL_WIDGET_TYPES = listOf(
     WidgetTypeInfo("CLOCK",       "CLOCK",       Icons.Default.AccessTime,  "Time & date"),
-    WidgetTypeInfo("WEATHER",     "WEATHER",     Icons.Default.Cloud,       "Current conditions"),
+    WidgetTypeInfo("WEATHER",     "WEATHER",     Icons.Default.Cloud,       "Current conditions", requiresNetwork = true),
     WidgetTypeInfo("NOW_PLAYING", "NOW PLAYING", Icons.Default.MusicNote,   "Media controls"),
     WidgetTypeInfo("TELEMETRY",   "COMPASS",     Icons.Default.Explore,     "Speed & heading"),
     WidgetTypeInfo("ALTIMETER",   "ALTIMETER",   Icons.Default.FlightTakeoff, "Roll, pitch & altitude"),
@@ -67,7 +72,7 @@ private val ALL_WIDGET_TYPES = listOf(
     WidgetTypeInfo("SOUNDBOARD",  "SOUNDBOARD",  Icons.Default.Piano,         "Custom sound pads"),
     WidgetTypeInfo("FUEL_LOG",    "FUEL LOG",    Icons.Default.LocalGasStation, "Fill-ups & efficiency"),
     WidgetTypeInfo("QUICK_TOGGLES", "TOGGLES",   Icons.Default.ToggleOn,      "WiFi, Bluetooth & DND"),
-    WidgetTypeInfo("LOCATION",    "LOCATION",    Icons.Default.GpsFixed,      "Live GPS coordinates")
+    WidgetTypeInfo("LOCATION",    "LOCATION",    Icons.Default.GpsFixed,      "Live GPS coordinates", requiresNetwork = true)
 )
 
 private fun canAddWidget(settings: com.openlauncher.app.data.AppSettings): Boolean {
@@ -1209,8 +1214,11 @@ private fun WidgetLibraryCard(
     val cardBg     = if (isActive) accent.copy(alpha = 0.15f) else if (isDayMode) Color(0xFFFFFFFF) else Color(0xFF0E0E0E)
     val iconTint   = if (isActive) accent else if (isDayMode) Color(0xFF495057) else Color(0xFF333333)
     val labelColor = if (isActive) accent else if (isDayMode) Color(0xFF212529) else Color(0xFF3A3A3A)
+    // Amber/yellow reads clearly against edit mode's grey card shading without
+    // being confused for the active-state accent color or an error state.
+    val networkTagColor = Color(0xFFE8A93D)
 
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
             .aspectRatio(1f)
@@ -1218,36 +1226,62 @@ private fun WidgetLibraryCard(
             .background(cardBg)
             .border(1.dp, cardBorder, RoundedCornerShape(4.dp))
             .clickable(enabled = enabled, onClick = onToggle)
-            .padding(6.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
     ) {
-        Icon(info.icon, null, tint = iconTint, modifier = Modifier.size(18.dp))
-        Spacer(Modifier.height(5.dp))
-        Text(
-            text          = info.label,
-            color         = labelColor,
-            fontSize      = 7.sp,
-            letterSpacing = 1.sp,
-            textAlign     = TextAlign.Center,
-            maxLines      = 2,
-            lineHeight    = 9.sp
-        )
-        Spacer(Modifier.height(3.dp))
-        Text(
-            text          = when {
-                isActive -> "ACTIVE"
-                !canAdd  -> "FULL"
-                else     -> "ADD"
-            },
-            color         = when {
-                isActive -> accent.copy(alpha = 0.75f)
-                !canAdd  -> if (isDayMode) Color(0xFFADB5BD) else Color(0xFF282828)
-                else     -> if (isDayMode) Color(0xFF495057) else Color(0xFF3A3A3A)
-            },
-            fontSize      = 6.sp,
-            letterSpacing = 1.sp,
-            textAlign     = TextAlign.Center
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(6.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Icon(info.icon, null, tint = iconTint, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.height(5.dp))
+            Text(
+                text          = info.label,
+                color         = labelColor,
+                fontSize      = 7.sp,
+                letterSpacing = 1.sp,
+                textAlign     = TextAlign.Center,
+                maxLines      = 2,
+                lineHeight    = 9.sp
+            )
+            Spacer(Modifier.height(3.dp))
+            Text(
+                text          = when {
+                    isActive -> "ACTIVE"
+                    !canAdd  -> "FULL"
+                    else     -> "ADD"
+                },
+                color         = when {
+                    isActive -> accent.copy(alpha = 0.75f)
+                    !canAdd  -> if (isDayMode) Color(0xFFADB5BD) else Color(0xFF282828)
+                    else     -> if (isDayMode) Color(0xFF495057) else Color(0xFF3A3A3A)
+                },
+                fontSize      = 6.sp,
+                letterSpacing = 1.sp,
+                textAlign     = TextAlign.Center
+            )
+            if (info.requiresNetwork) {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text          = "NEEDS DATA",
+                    color         = networkTagColor,
+                    fontSize      = 5.sp,
+                    letterSpacing = 0.5.sp,
+                    textAlign     = TextAlign.Center
+                )
+            }
+        }
+        if (info.requiresNetwork) {
+            Icon(
+                imageVector        = Icons.Default.Wifi,
+                contentDescription = "Requires internet connection",
+                tint               = networkTagColor,
+                modifier           = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(4.dp)
+                    .size(10.dp)
+            )
+        }
     }
 }

--- a/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
@@ -135,6 +135,7 @@ fun HomeScreen(
     onSetSpeedometerDigitalOnly: (Boolean) -> Unit = {},
     onSetLocationDetailLevel: (com.openlauncher.app.data.LocationDetailLevel) -> Unit = {},
     onUpdateSoundPad: (index: Int, pad: com.openlauncher.app.data.SoundPadConfig) -> Unit = { _, _ -> },
+    onUpdate: (AppSettings.() -> AppSettings) -> Unit = {},
     hardwareRadio: com.openlauncher.app.viewmodel.LauncherViewModel.HardwareRadioState? = null,
     onLaunchHardwareRadio: () -> Unit = {},
     onStopHardwareRadio: () -> Unit = {},
@@ -451,6 +452,10 @@ fun HomeScreen(
                             style      = settings.clockStyle,
                             accent     = accent,
                             isDayMode  = isDayMode,
+                            location   = location,
+                            showSunriseSunset = settings.showSunriseSunset,
+                            showQuickToggles  = settings.showQuickTogglesInClock,
+                            isEditing  = editMode,
                             modifier   = Modifier.fillMaxSize()
                         )
                         "WEATHER" -> WeatherWidget(
@@ -460,6 +465,9 @@ fun HomeScreen(
                             isDayMode  = isDayMode,
                             location   = location,
                             placeName  = placeName,
+                            showWindSpeed  = settings.showWindSpeed,
+                            showFeelsLike  = settings.showFeelsLike,
+                            showRainChance = settings.showRainChance,
                             modifier   = Modifier.fillMaxSize()
                         )
                         "NOW_PLAYING" -> NowPlayingWidget(
@@ -484,7 +492,8 @@ fun HomeScreen(
                             onRadioCycleFm        = onRadioCycleFm,
                             onRadioSwitchAm       = onRadioSwitchAm,
                             onRadioTune           = onRadioTune,
-                            onAssignRadio         = onAssignRadio
+                            onAssignRadio         = onAssignRadio,
+                            showSourceBadge       = settings.showNowPlayingSourceBadge
                         )
                         "TELEMETRY" -> TelemetryWidget(
                             location  = location,
@@ -587,6 +596,12 @@ fun HomeScreen(
             carPlayPackage      = settings.carPlayPackage,
             androidAutoPackage  = settings.androidAutoPackage,
             pipAppPackage       = settings.pipAppPackage,
+            showSunriseSunset   = settings.showSunriseSunset,
+            showQuickTogglesInClock = settings.showQuickTogglesInClock,
+            showWindSpeed       = settings.showWindSpeed,
+            showFeelsLike       = settings.showFeelsLike,
+            showRainChance      = settings.showRainChance,
+            showNowPlayingSourceBadge = settings.showNowPlayingSourceBadge,
             isDayMode           = isDayMode,
             onResize            = { contextMenuId = null; resizingId = id },
             onAssignCarPlay     = { contextMenuId = null; onAssignCarPlay() },
@@ -599,6 +614,7 @@ fun HomeScreen(
             onSetVitalsAsBars   = { onSetVitalsAsBars(it) },
             onSetSpeedometerDigitalOnly = { onSetSpeedometerDigitalOnly(it) },
             onSetLocationDetailLevel = { onSetLocationDetailLevel(it) },
+            onToggle            = { block -> onUpdate(block) },
             onDismiss           = { contextMenuId = null }
         )
     }
@@ -753,6 +769,12 @@ private fun WidgetContextMenu(
     carPlayPackage: String = "",
     androidAutoPackage: String = "",
     pipAppPackage: String = "",
+    showSunriseSunset: Boolean = true,
+    showQuickTogglesInClock: Boolean = true,
+    showWindSpeed: Boolean = true,
+    showFeelsLike: Boolean = true,
+    showRainChance: Boolean = true,
+    showNowPlayingSourceBadge: Boolean = true,
     isDayMode: Boolean,
     onResize: () -> Unit,
     onAssignCarPlay: () -> Unit,
@@ -765,6 +787,7 @@ private fun WidgetContextMenu(
     onSetVitalsAsBars: (Boolean) -> Unit,
     onSetSpeedometerDigitalOnly: (Boolean) -> Unit,
     onSetLocationDetailLevel: (com.openlauncher.app.data.LocationDetailLevel) -> Unit = {},
+    onToggle: (AppSettings.() -> AppSettings) -> Unit = {},
     onDismiss: () -> Unit
 ) {
     val menuBg    = if (isDayMode) Color(0xFFFFFFFF) else Color(0xFF111111)
@@ -796,6 +819,22 @@ private fun WidgetContextMenu(
                     icon    = Icons.Default.Watch,
                     tint    = if (clockStyle == ClockStyle.ANALOG) accent else inactiveMenuTint,
                     onClick = { onSetClockStyle(ClockStyle.ANALOG); onDismiss() },
+                    isDayMode = isDayMode
+                )
+                HorizontalDivider(color = menuDivider)
+                ContextRow(
+                    label   = if (showSunriseSunset) "SUNRISE/SUNSET  ON" else "SUNRISE/SUNSET  OFF",
+                    icon    = Icons.Default.WbSunny,
+                    tint    = if (showSunriseSunset) accent else inactiveMenuTint,
+                    onClick = { onToggle { copy(showSunriseSunset = !showSunriseSunset) } },
+                    isDayMode = isDayMode
+                )
+                HorizontalDivider(color = menuDivider)
+                ContextRow(
+                    label   = if (showQuickTogglesInClock) "QUICK TOGGLES  ON" else "QUICK TOGGLES  OFF",
+                    icon    = Icons.Default.Wifi,
+                    tint    = if (showQuickTogglesInClock) accent else inactiveMenuTint,
+                    onClick = { onToggle { copy(showQuickTogglesInClock = !showQuickTogglesInClock) } },
                     isDayMode = isDayMode
                 )
             }
@@ -852,7 +891,41 @@ private fun WidgetContextMenu(
                     )
                 }
             }
+            if (widgetId == "WEATHER") {
+                HorizontalDivider(color = menuDivider)
+                ContextRow(
+                    label   = if (showWindSpeed) "WIND SPEED  ON" else "WIND SPEED  OFF",
+                    icon    = Icons.Default.Air,
+                    tint    = if (showWindSpeed) accent else inactiveMenuTint,
+                    onClick = { onToggle { copy(showWindSpeed = !showWindSpeed) } },
+                    isDayMode = isDayMode
+                )
+                HorizontalDivider(color = menuDivider)
+                ContextRow(
+                    label   = if (showFeelsLike) "FEELS LIKE  ON" else "FEELS LIKE  OFF",
+                    icon    = Icons.Default.Thermostat,
+                    tint    = if (showFeelsLike) accent else inactiveMenuTint,
+                    onClick = { onToggle { copy(showFeelsLike = !showFeelsLike) } },
+                    isDayMode = isDayMode
+                )
+                HorizontalDivider(color = menuDivider)
+                ContextRow(
+                    label   = if (showRainChance) "RAIN CHANCE  ON" else "RAIN CHANCE  OFF",
+                    icon    = Icons.Default.WaterDrop,
+                    tint    = if (showRainChance) accent else inactiveMenuTint,
+                    onClick = { onToggle { copy(showRainChance = !showRainChance) } },
+                    isDayMode = isDayMode
+                )
+            }
             if (widgetId == "NOW_PLAYING") {
+                HorizontalDivider(color = menuDivider)
+                ContextRow(
+                    label   = if (showNowPlayingSourceBadge) "SOURCE BADGE  ON" else "SOURCE BADGE  OFF",
+                    icon    = Icons.Default.Apps,
+                    tint    = if (showNowPlayingSourceBadge) accent else inactiveMenuTint,
+                    onClick = { onToggle { copy(showNowPlayingSourceBadge = !showNowPlayingSourceBadge) } },
+                    isDayMode = isDayMode
+                )
                 HorizontalDivider(color = menuDivider)
                 ContextRow("ASSIGN CARPLAY APP",      Icons.Default.PhoneAndroid,  accent, onAssignCarPlay, isDayMode = isDayMode)
                 if (carPlayPackage.isNotEmpty()) {

--- a/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
@@ -456,6 +456,7 @@ fun HomeScreen(
                             showSunriseSunset = settings.showSunriseSunset,
                             showQuickToggles  = settings.showQuickTogglesInClock,
                             isEditing  = editMode,
+                            use24HourFormat = settings.use24HourFormat,
                             modifier   = Modifier.fillMaxSize()
                         )
                         "WEATHER" -> WeatherWidget(
@@ -596,6 +597,7 @@ fun HomeScreen(
             carPlayPackage      = settings.carPlayPackage,
             androidAutoPackage  = settings.androidAutoPackage,
             pipAppPackage       = settings.pipAppPackage,
+            use24HourFormat     = settings.use24HourFormat,
             showSunriseSunset   = settings.showSunriseSunset,
             showQuickTogglesInClock = settings.showQuickTogglesInClock,
             showWindSpeed       = settings.showWindSpeed,
@@ -769,6 +771,7 @@ private fun WidgetContextMenu(
     carPlayPackage: String = "",
     androidAutoPackage: String = "",
     pipAppPackage: String = "",
+    use24HourFormat: Boolean = true,
     showSunriseSunset: Boolean = true,
     showQuickTogglesInClock: Boolean = true,
     showWindSpeed: Boolean = true,
@@ -819,6 +822,14 @@ private fun WidgetContextMenu(
                     icon    = Icons.Default.Watch,
                     tint    = if (clockStyle == ClockStyle.ANALOG) accent else inactiveMenuTint,
                     onClick = { onSetClockStyle(ClockStyle.ANALOG); onDismiss() },
+                    isDayMode = isDayMode
+                )
+                HorizontalDivider(color = menuDivider)
+                ContextRow(
+                    label   = if (use24HourFormat) "24-HOUR" else "12-HOUR",
+                    icon    = Icons.Default.Schedule,
+                    tint    = accent,
+                    onClick = { onToggle { copy(use24HourFormat = !use24HourFormat) } },
                     isDayMode = isDayMode
                 )
                 HorizontalDivider(color = menuDivider)

--- a/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
@@ -64,7 +64,10 @@ private val ALL_WIDGET_TYPES = listOf(
     WidgetTypeInfo("SPEEDOMETER", "SPEED",       Icons.Default.Speed,         "GPS speed"),
     WidgetTypeInfo("VITALS",      "VITALS",      Icons.Default.Dns,           "Head Unit Health / Vitals"),
     WidgetTypeInfo("TRIP_TRACKER", "TRIP TRACKER", Icons.Default.Map,          "Trip logs & stats"),
-    WidgetTypeInfo("SOUNDBOARD",  "SOUNDBOARD",  Icons.Default.Piano,         "Custom sound pads")
+    WidgetTypeInfo("SOUNDBOARD",  "SOUNDBOARD",  Icons.Default.Piano,         "Custom sound pads"),
+    WidgetTypeInfo("FUEL_LOG",    "FUEL LOG",    Icons.Default.LocalGasStation, "Fill-ups & efficiency"),
+    WidgetTypeInfo("QUICK_TOGGLES", "TOGGLES",   Icons.Default.ToggleOn,      "WiFi, Bluetooth & DND"),
+    WidgetTypeInfo("LOCATION",    "LOCATION",    Icons.Default.GpsFixed,      "Live GPS coordinates")
 )
 
 private fun canAddWidget(settings: com.openlauncher.app.data.AppSettings): Boolean {
@@ -78,6 +81,9 @@ private fun canAddWidget(settings: com.openlauncher.app.data.AppSettings): Boole
         if (settings.showVitals) add("VITALS")
         if (settings.showTripTracker) add("TRIP_TRACKER")
         if (settings.showSoundboard) add("SOUNDBOARD")
+        if (settings.showFuelLog) add("FUEL_LOG")
+        if (settings.showQuickToggles) add("QUICK_TOGGLES")
+        if (settings.showLocation) add("LOCATION")
     }
     val activeWidgets = settings.widgetLayout.filter { it.enabled && it.id in visibleIds }
     val occupied = buildSet<Pair<Int, Int>> {
@@ -99,9 +105,11 @@ fun HomeScreen(
     weather: WeatherState?,
     nowPlaying: NowPlayingState?,
     location: LocationData?,
+    placeName: String? = null,
     bearing: Float,
     isWifi: Boolean,
     isData: Boolean,
+    voltage: Float? = null,
     isDayMode: Boolean = false,
     onPlayPause: () -> Unit,
     onNext: () -> Unit,
@@ -120,6 +128,8 @@ fun HomeScreen(
     onMoveWidget: (id: String, gridX: Int, gridY: Int) -> Unit,
     onAddWidget: (id: String) -> Unit,
     onRemoveWidget: (id: String) -> Unit,
+    onApplyPreset: (List<WidgetConfig>) -> Unit = {},
+    onAddFuelEntry: (odometerKm: Double, volume: Double, cost: Double) -> Unit = { _, _, _ -> },
     onSetClockStyle: (ClockStyle) -> Unit,
     onSetVitalsAsBars: (Boolean) -> Unit = {},
     onSetSpeedometerDigitalOnly: (Boolean) -> Unit = {},
@@ -135,15 +145,21 @@ fun HomeScreen(
     onAssignRadio: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
-    val accent       = Color(settings.accentColor)
+    // A preset themeId supplies its own accent + tile surface for the current mode;
+    // "custom" (or an unrecognized id) falls through to the manually-picked accent
+    // and the original wallpaper/day-mode tile logic below, unchanged.
+    val resolvedTheme = com.openlauncher.app.data.resolveDashboardTheme(settings.themeId, isDayMode)
+    val accent       = resolvedTheme?.accent ?: Color(settings.accentColor)
     val gap          = 6.dp
     val hasWallpaper = settings.wallpaperUri.isNotEmpty()
     val widgetBg     = when {
+        resolvedTheme != null && !hasWallpaper -> resolvedTheme.background
         isDayMode    -> Color(0xFFFFFFFF)
         hasWallpaper -> Color(0xCC000000)
         else         -> Color.Black.copy(alpha = 0.35f)
     }
     val widgetBorder = when {
+        resolvedTheme != null && !hasWallpaper -> accent.copy(alpha = if (isDayMode) 0.35f else 0.25f)
         isDayMode    -> Color(0xFFCCCCCC)
         hasWallpaper -> Color(0x22FFFFFF)
         else         -> MaterialTheme.colorScheme.onBackground.copy(alpha = 0.08f)
@@ -159,6 +175,7 @@ fun HomeScreen(
     val isLandscape      = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
     var editMode         by remember { mutableStateOf(false) }
     var widgetLibraryOpen by remember { mutableStateOf(false) }
+    var presetPickerOpen by remember { mutableStateOf(false) }
 
     Column(modifier = modifier.fillMaxSize()) {
 
@@ -178,6 +195,19 @@ fun HomeScreen(
                 fontSize      = 14.sp
             )
             Spacer(Modifier.weight(1f))
+            if (voltage != null) {
+                val voltageColor = if (voltage < 12f) Color(0xFFE05252) else statusIconColor
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Icon(Icons.Default.Bolt, "Voltage", tint = voltageColor, modifier = Modifier.size(14.dp))
+                    Text(
+                        text = "%.1fV".format(voltage),
+                        color = voltageColor,
+                        fontSize = 11.sp,
+                        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+            }
             AnimatedVisibility(visible = isWifi, enter = fadeIn(), exit = fadeOut()) {
                 Icon(Icons.Default.Wifi, "WiFi", tint = statusIconColor, modifier = Modifier.size(16.dp))
             }
@@ -195,6 +225,18 @@ fun HomeScreen(
                         Icon(
                             imageVector        = Icons.Default.Dashboard,
                             contentDescription = "Widget library",
+                            tint               = controlIconColor,
+                            modifier           = Modifier.size(15.dp)
+                        )
+                    }
+                    Spacer(Modifier.width(2.dp))
+                    IconButton(
+                        onClick  = { presetPickerOpen = true },
+                        modifier = Modifier.size(28.dp)
+                    ) {
+                        Icon(
+                            imageVector        = Icons.Default.ViewQuilt,
+                            contentDescription = "Layout presets",
                             tint               = controlIconColor,
                             modifier           = Modifier.size(15.dp)
                         )
@@ -243,6 +285,9 @@ fun HomeScreen(
                 if (settings.showVitals) add("VITALS")
                 if (settings.showTripTracker) add("TRIP_TRACKER")
                 if (settings.showSoundboard) add("SOUNDBOARD")
+                if (settings.showFuelLog) add("FUEL_LOG")
+                if (settings.showQuickToggles) add("QUICK_TOGGLES")
+                if (settings.showLocation) add("LOCATION")
             }
 
             // Keep only visible widgets exactly as configured in settings, allowing explicit resizing to dictate layout
@@ -310,7 +355,9 @@ fun HomeScreen(
                 val height = cellH * w.spanY + gap * (w.spanY - 1)
 
                 val label = when (w.id) {
-                    "CLOCK"       -> clockTimeLabel(Calendar.getInstance())
+                    // CLOCK renders its own greeting/icon row internally now — the generic
+                    // corner label would just duplicate it (this was the "two MORNING" bug).
+                    "CLOCK"       -> ""
                     "WEATHER"     -> "WEATHER"
                     "NOW_PLAYING" -> "NOW PLAYING"
                     "TELEMETRY"   -> "COMPASS"
@@ -318,6 +365,11 @@ fun HomeScreen(
                     "SPEEDOMETER" -> "SPEED"
                     "TRIP_TRACKER" -> "TRIP"
                     "SOUNDBOARD"  -> "SOUND"
+                    "FUEL_LOG"    -> "FUEL"
+                    "QUICK_TOGGLES" -> "TOGGLES"
+                    // LOCATION renders its own "LIVE LOCATION" header internally —
+                    // same duplicate-label issue the Clock widget had.
+                    "LOCATION"    -> ""
                     else          -> w.id
                 }
 
@@ -405,6 +457,8 @@ fun HomeScreen(
                             accent     = accent,
                             metric     = settings.unitSystem.name == "METRIC",
                             isDayMode  = isDayMode,
+                            location   = location,
+                            placeName  = placeName,
                             modifier   = Modifier.fillMaxSize()
                         )
                         "NOW_PLAYING" -> NowPlayingWidget(
@@ -474,12 +528,34 @@ fun HomeScreen(
                             onUpdatePad = onUpdateSoundPad,
                             modifier  = Modifier.fillMaxSize()
                         )
+                        "FUEL_LOG" -> FuelLogWidget(
+                            entries   = settings.fuelLog,
+                            isMetric  = settings.unitSystem == com.openlauncher.app.data.UnitSystem.METRIC,
+                            accent    = accent,
+                            isDayMode = isDayMode,
+                            isEditing = editMode,
+                            onAddEntry = onAddFuelEntry,
+                            modifier  = Modifier.fillMaxSize()
+                        )
+                        "QUICK_TOGGLES" -> QuickTogglesWidget(
+                            accent    = accent,
+                            isDayMode = isDayMode,
+                            isEditing = editMode,
+                            modifier  = Modifier.fillMaxSize()
+                        )
+                        "LOCATION" -> LocationWidget(
+                            location  = location,
+                            placeName = placeName,
+                            accent    = accent,
+                            isDayMode = isDayMode,
+                            modifier  = Modifier.fillMaxSize()
+                        )
                     }
 
-                    // Label — hide when album art fills the widget background
+                    // Label — Now Playing's art is a small thumbnail now, not a full-bleed
+                    // background, so the corner label no longer needs to hide behind it.
                     val labelColor = when {
                         isGhost -> Color.Transparent
-                        w.id == "NOW_PLAYING" && nowPlaying?.albumArt != null && nowPlaying.title.isNotEmpty() -> Color.Transparent
                         isDayMode -> Color(0xFF999999)
                         else      -> Color(0xFF3A3A3A)
                     }
@@ -551,6 +627,115 @@ fun HomeScreen(
             onRemove  = { id -> onRemoveWidget(id) },
             onDismiss = { widgetLibraryOpen = false }
         )
+    }
+
+    // ── Layout presets ───────────────────────────────────────────────────────
+    if (presetPickerOpen) {
+        LayoutPresetDialog(
+            accent    = accent,
+            isDayMode = isDayMode,
+            onApply   = { preset -> onApplyPreset(preset); presetPickerOpen = false },
+            onDismiss = { presetPickerOpen = false }
+        )
+    }
+}
+
+private data class LayoutPresetInfo(
+    val label: String,
+    val description: String,
+    val icon: ImageVector,
+    val layout: List<WidgetConfig>
+)
+
+private val LAYOUT_PRESETS = listOf(
+    LayoutPresetInfo(
+        label       = "DEFAULT",
+        description = "Clock, weather, compass & now playing — balanced grid",
+        icon        = Icons.Default.GridView,
+        layout      = com.openlauncher.app.data.defaultWidgetLayout()
+    ),
+    LayoutPresetInfo(
+        label       = "SPLIT PANEL",
+        description = "Big media card on the left, weather & clock stacked on the right",
+        icon        = Icons.Default.ViewQuilt,
+        layout      = com.openlauncher.app.data.splitPanelWidgetLayout()
+    )
+)
+
+@Composable
+private fun LayoutPresetDialog(
+    accent: Color,
+    isDayMode: Boolean,
+    onApply: (List<WidgetConfig>) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val dialogBg    = if (isDayMode) Color(0xFFEEEEEE) else Color(0xFF0C0C0C)
+    val dialogBorder = if (isDayMode) Color(0xFFCCCCCC) else Color(0xFF1E1E1E)
+    val titleColor  = if (isDayMode) Color(0xFF495057) else Color(0xFF555555)
+    val closeColor  = if (isDayMode) Color(0xFF495057) else Color(0xFF444444)
+    val labelColor  = if (isDayMode) Color(0xFF212529) else Color(0xFFDDDDDD)
+    val descColor   = if (isDayMode) Color(0xFF6C757D) else Color(0xFF888888)
+    val cardBg      = if (isDayMode) Color(0xFFFFFFFF) else Color(0xFF0E0E0E)
+    val cardBorder  = if (isDayMode) Color(0xFFCCCCCC) else Color(0xFF1A1A1A)
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(4.dp))
+                .background(dialogBg)
+                .border(1.dp, dialogBorder, RoundedCornerShape(4.dp))
+                .padding(16.dp)
+                .widthIn(min = 280.dp, max = 420.dp)
+        ) {
+            Row(
+                modifier          = Modifier.fillMaxWidth().padding(bottom = 14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text          = "LAYOUT PRESETS",
+                    color         = titleColor,
+                    fontSize      = 9.sp,
+                    letterSpacing = 2.sp
+                )
+                Spacer(Modifier.weight(1f))
+                IconButton(onClick = onDismiss, modifier = Modifier.size(24.dp)) {
+                    Icon(Icons.Default.Close, null, tint = closeColor, modifier = Modifier.size(14.dp))
+                }
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                LAYOUT_PRESETS.forEach { preset ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(cardBg)
+                            .border(1.dp, cardBorder, RoundedCornerShape(4.dp))
+                            .clickable { onApply(preset.layout) }
+                            .padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Icon(preset.icon, null, tint = accent, modifier = Modifier.size(20.dp))
+                        Column {
+                            Text(
+                                text          = preset.label,
+                                color         = labelColor,
+                                fontSize      = 11.sp,
+                                letterSpacing = 1.sp
+                            )
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                text     = preset.description,
+                                color    = descColor,
+                                fontSize = 9.sp,
+                                lineHeight = 12.sp
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -839,6 +1024,9 @@ private fun WidgetLibraryDialog(
         if (settings.showVitals) add("VITALS")
         if (settings.showTripTracker) add("TRIP_TRACKER")
         if (settings.showSoundboard) add("SOUNDBOARD")
+        if (settings.showFuelLog) add("FUEL_LOG")
+        if (settings.showQuickToggles) add("QUICK_TOGGLES")
+        if (settings.showLocation) add("LOCATION")
     }
     val canAdd = canAddWidget(settings)
 

--- a/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/screen/HomeScreen.kt
@@ -133,6 +133,7 @@ fun HomeScreen(
     onSetClockStyle: (ClockStyle) -> Unit,
     onSetVitalsAsBars: (Boolean) -> Unit = {},
     onSetSpeedometerDigitalOnly: (Boolean) -> Unit = {},
+    onSetLocationDetailLevel: (com.openlauncher.app.data.LocationDetailLevel) -> Unit = {},
     onUpdateSoundPad: (index: Int, pad: com.openlauncher.app.data.SoundPadConfig) -> Unit = { _, _ -> },
     hardwareRadio: com.openlauncher.app.viewmodel.LauncherViewModel.HardwareRadioState? = null,
     onLaunchHardwareRadio: () -> Unit = {},
@@ -582,6 +583,7 @@ fun HomeScreen(
             clockStyle          = settings.clockStyle,
             vitalsAsBars        = settings.vitalsAsBars,
             speedometerDigitalOnly = settings.speedometerDigitalOnly,
+            locationDetailLevel = settings.locationDetailLevel,
             carPlayPackage      = settings.carPlayPackage,
             androidAutoPackage  = settings.androidAutoPackage,
             pipAppPackage       = settings.pipAppPackage,
@@ -596,6 +598,7 @@ fun HomeScreen(
             onSetClockStyle     = { onSetClockStyle(it) },
             onSetVitalsAsBars   = { onSetVitalsAsBars(it) },
             onSetSpeedometerDigitalOnly = { onSetSpeedometerDigitalOnly(it) },
+            onSetLocationDetailLevel = { onSetLocationDetailLevel(it) },
             onDismiss           = { contextMenuId = null }
         )
     }
@@ -746,6 +749,7 @@ private fun WidgetContextMenu(
     clockStyle: ClockStyle,
     vitalsAsBars: Boolean,
     speedometerDigitalOnly: Boolean,
+    locationDetailLevel: com.openlauncher.app.data.LocationDetailLevel = com.openlauncher.app.data.LocationDetailLevel.NEIGHBORHOOD,
     carPlayPackage: String = "",
     androidAutoPackage: String = "",
     pipAppPackage: String = "",
@@ -760,6 +764,7 @@ private fun WidgetContextMenu(
     onSetClockStyle: (ClockStyle) -> Unit,
     onSetVitalsAsBars: (Boolean) -> Unit,
     onSetSpeedometerDigitalOnly: (Boolean) -> Unit,
+    onSetLocationDetailLevel: (com.openlauncher.app.data.LocationDetailLevel) -> Unit = {},
     onDismiss: () -> Unit
 ) {
     val menuBg    = if (isDayMode) Color(0xFFFFFFFF) else Color(0xFF111111)
@@ -829,6 +834,23 @@ private fun WidgetContextMenu(
                     onClick = { onSetSpeedometerDigitalOnly(true); onDismiss() },
                     isDayMode = isDayMode
                 )
+            }
+            if (widgetId == "LOCATION") {
+                val levels = com.openlauncher.app.data.LocationDetailLevel.entries
+                levels.forEach { level ->
+                    HorizontalDivider(color = menuDivider)
+                    ContextRow(
+                        label   = when (level) {
+                            com.openlauncher.app.data.LocationDetailLevel.NEIGHBORHOOD -> "NEIGHBORHOOD"
+                            com.openlauncher.app.data.LocationDetailLevel.CITY         -> "CITY"
+                            com.openlauncher.app.data.LocationDetailLevel.REGION       -> "REGION / STATE"
+                        },
+                        icon    = Icons.Default.Explore,
+                        tint    = if (locationDetailLevel == level) accent else inactiveMenuTint,
+                        onClick = { onSetLocationDetailLevel(level); onDismiss() },
+                        isDayMode = isDayMode
+                    )
+                }
             }
             if (widgetId == "NOW_PLAYING") {
                 HorizontalDivider(color = menuDivider)

--- a/app/src/main/java/com/openlauncher/app/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/screen/SettingsScreen.kt
@@ -6,9 +6,12 @@ import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -19,14 +22,17 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.openlauncher.app.data.AppFont
 import com.openlauncher.app.data.AppSettings
+import com.openlauncher.app.data.DASHBOARD_THEMES
 import com.openlauncher.app.data.DayNightMode
 import com.openlauncher.app.data.SidebarPosition
 import com.openlauncher.app.data.ShortcutConfig
@@ -381,6 +387,12 @@ fun SettingsScreen(
 
         // ── Appearance ───────────────────────────────────────────────────────
         SettingsSection("Appearance") {
+            // Dashboard Theme — a preset owns both accent and surface tint together;
+            // Accent Color / Background below only apply once this is set to Custom.
+            DashboardThemeRow(settings = settings, onUpdate = onUpdate)
+
+            SettingsDivider()
+
             // Display Mode
             SettingsRow(
                 label    = "Display Mode",
@@ -852,6 +864,95 @@ fun SettingsScreen(
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+@Composable
+private fun DashboardThemeRow(
+    settings: AppSettings,
+    onUpdate: (AppSettings.() -> AppSettings) -> Unit
+) {
+    val isDayMode  = LocalDayMode.current
+    val labelColor = if (isDayMode) Color(0xFF111111) else Color(0xFFDDDDDD)
+    val subColor   = if (isDayMode) Color(0xFF888888) else Color(0xFF444444)
+    val iconTint   = if (isDayMode) Color(0xFF777777) else MaterialTheme.colorScheme.primary.copy(alpha = 0.55f)
+    val isCustom   = DASHBOARD_THEMES.none { it.id == settings.themeId }
+
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 11.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.Palette, null, tint = iconTint, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(14.dp))
+            Column {
+                Text("Dashboard Theme", style = MaterialTheme.typography.bodyMedium, color = labelColor, fontSize = 13.sp)
+                Text(
+                    text     = DASHBOARD_THEMES.find { it.id == settings.themeId }?.label ?: "Custom",
+                    style    = MaterialTheme.typography.labelSmall,
+                    color    = subColor,
+                    fontSize = 11.sp
+                )
+            }
+        }
+        Spacer(Modifier.height(10.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            DASHBOARD_THEMES.forEach { theme ->
+                ThemeSwatchButton(
+                    label         = theme.label,
+                    gradientStart = Color(theme.darkAccent),
+                    gradientEnd   = Color(theme.darkBg),
+                    selected      = settings.themeId == theme.id,
+                    onClick       = { onUpdate { copy(themeId = theme.id) } }
+                )
+            }
+            ThemeSwatchButton(
+                label         = "Custom",
+                gradientStart = Color(settings.accentColor),
+                gradientEnd   = Color(settings.backgroundColor),
+                selected      = isCustom,
+                onClick       = { onUpdate { copy(themeId = "custom") } }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ThemeSwatchButton(
+    label: String,
+    gradientStart: Color,
+    gradientEnd: Color,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    val isDayMode  = LocalDayMode.current
+    val labelColor = if (selected) gradientStart else if (isDayMode) Color(0xFF888888) else Color(0xFF666666)
+    Column(
+        horizontalAlignment  = Alignment.CenterHorizontally,
+        verticalArrangement  = Arrangement.spacedBy(4.dp),
+        modifier             = Modifier.width(54.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(Brush.linearGradient(listOf(gradientStart, gradientEnd)))
+                .border(
+                    width = if (selected) 2.dp else 1.dp,
+                    color = if (selected) gradientStart else Color(0x33808080),
+                    shape = CircleShape
+                )
+                .clickable(onClick = onClick)
+        )
+        Text(
+            text          = label,
+            color         = labelColor,
+            fontSize      = 7.sp,
+            letterSpacing = 0.3.sp,
+            textAlign     = TextAlign.Center,
+            maxLines      = 2,
+            lineHeight    = 8.sp
+        )
+    }
+}
 
 @Composable
 private fun SettingsSection(

--- a/app/src/main/java/com/openlauncher/app/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/screen/SettingsScreen.kt
@@ -38,6 +38,7 @@ import com.openlauncher.app.data.SidebarPosition
 import com.openlauncher.app.data.ShortcutConfig
 import com.openlauncher.app.data.GradientDirection
 import com.openlauncher.app.data.UnitSystem
+import com.openlauncher.app.data.LocationRefreshInterval
 import com.openlauncher.app.ui.theme.LocalDayMode
 import com.openlauncher.app.ui.theme.onAccentColor
 import com.openlauncher.app.util.SunriseSunset
@@ -343,6 +344,39 @@ fun SettingsScreen(
                             selectedLabelColor     = onAccentColor(accent)
                         )
                     )
+                }
+            }
+
+            SettingsDivider()
+
+            SettingsRow(
+                label    = "Location Refresh",
+                sublabel = "How often the live neighborhood name updates while driving (Weather + Location)",
+                icon     = Icons.Default.GpsFixed
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    LocationRefreshInterval.entries.forEach { interval ->
+                        FilterChip(
+                            selected = settings.locationRefreshInterval == interval,
+                            onClick  = { onUpdate { copy(locationRefreshInterval = interval) } },
+                            label    = {
+                                Text(
+                                    when (interval) {
+                                        LocationRefreshInterval.SEC_30 -> "30s"
+                                        LocationRefreshInterval.MIN_1  -> "1min"
+                                        LocationRefreshInterval.MIN_2  -> "2min"
+                                        LocationRefreshInterval.MIN_5  -> "5min"
+                                    },
+                                    fontSize = 9.sp,
+                                    letterSpacing = 0.5.sp
+                                )
+                            },
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = accent,
+                                selectedLabelColor     = onAccentColor(accent)
+                            )
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/openlauncher/app/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/screen/SettingsScreen.kt
@@ -39,6 +39,7 @@ import com.openlauncher.app.data.ShortcutConfig
 import com.openlauncher.app.data.GradientDirection
 import com.openlauncher.app.data.UnitSystem
 import com.openlauncher.app.ui.theme.LocalDayMode
+import com.openlauncher.app.ui.theme.onAccentColor
 import com.openlauncher.app.util.SunriseSunset
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
@@ -297,7 +298,7 @@ fun SettingsScreen(
                             },
                             colors = FilterChipDefaults.filterChipColors(
                                 selectedContainerColor = accent,
-                                selectedLabelColor     = Color.Black
+                                selectedLabelColor     = onAccentColor(accent)
                             )
                         )
                     }
@@ -329,7 +330,7 @@ fun SettingsScreen(
                         label    = { Text("Metric", fontSize = 11.sp) },
                         colors   = FilterChipDefaults.filterChipColors(
                             selectedContainerColor = accent,
-                            selectedLabelColor     = Color.Black
+                            selectedLabelColor     = onAccentColor(accent)
                         )
                     )
                     Spacer(Modifier.width(6.dp))
@@ -339,7 +340,7 @@ fun SettingsScreen(
                         label    = { Text("Imperial", fontSize = 11.sp) },
                         colors   = FilterChipDefaults.filterChipColors(
                             selectedContainerColor = accent,
-                            selectedLabelColor     = Color.Black
+                            selectedLabelColor     = onAccentColor(accent)
                         )
                     )
                 }
@@ -428,7 +429,7 @@ fun SettingsScreen(
                             },
                             colors = FilterChipDefaults.filterChipColors(
                                 selectedContainerColor = accent,
-                                selectedLabelColor     = Color.Black
+                                selectedLabelColor     = onAccentColor(accent)
                             )
                         )
                     }
@@ -562,7 +563,7 @@ fun SettingsScreen(
                                 },
                                 colors = FilterChipDefaults.filterChipColors(
                                     selectedContainerColor = accent,
-                                    selectedLabelColor     = Color.Black
+                                    selectedLabelColor     = onAccentColor(accent)
                                 )
                             )
                         }
@@ -617,7 +618,7 @@ fun SettingsScreen(
                             label    = { Text(fontDisplayName(font), fontSize = 9.sp, letterSpacing = 0.5.sp) },
                             colors   = FilterChipDefaults.filterChipColors(
                                 selectedContainerColor = accent,
-                                selectedLabelColor     = Color.Black
+                                selectedLabelColor     = onAccentColor(accent)
                             )
                         )
                     }

--- a/app/src/main/java/com/openlauncher/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/theme/Theme.kt
@@ -12,6 +12,12 @@ import com.openlauncher.app.data.AppFont
 
 val LocalDayMode = staticCompositionLocalOf { false }
 
+// Contrast-aware label color for content sitting directly on an accent fill
+// (selected FilterChips, etc.) — several of the dashboard theme accents are
+// dark even in light mode (e.g. Instrument Cluster's navy), so a fixed black
+// label goes unreadable on them.
+fun onAccentColor(accent: Color): Color = if (accent.luminance() > 0.5f) Color.Black else Color.White
+
 @Composable
 fun OpenLauncherTheme(
     accent: Color     = AccentWhite,

--- a/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
@@ -41,6 +41,7 @@ fun ClockWidget(
     showSunriseSunset: Boolean = true,
     showQuickToggles: Boolean = true,
     isEditing: Boolean = false,
+    use24HourFormat: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     var calendar by remember { mutableStateOf(Calendar.getInstance()) }
@@ -60,7 +61,8 @@ fun ClockWidget(
             ClockStyle.DIGITAL -> DigitalClock(
                 cal = calendar, contentColor = contentColor, subColor = subColor, accent = accent,
                 location = location, showSunriseSunset = showSunriseSunset,
-                showQuickToggles = showQuickToggles, isDayMode = isDayMode, isEditing = isEditing
+                showQuickToggles = showQuickToggles, isDayMode = isDayMode, isEditing = isEditing,
+                use24HourFormat = use24HourFormat
             )
             ClockStyle.ANALOG  -> AnalogClock(calendar, accent, isDayMode)
         }
@@ -77,11 +79,18 @@ private fun DigitalClock(
     showSunriseSunset: Boolean,
     showQuickToggles: Boolean,
     isDayMode: Boolean,
-    isEditing: Boolean
+    isEditing: Boolean,
+    use24HourFormat: Boolean
 ) {
     val hour   = cal.get(Calendar.HOUR_OF_DAY)
     val minute = cal.get(Calendar.MINUTE)
     val isDaylightHour = hour in 6..17
+    val timeText = if (use24HourFormat) {
+        "%02d:%02d".format(hour, minute)
+    } else {
+        val h12 = when (hour % 12) { 0 -> 12; else -> hour % 12 }
+        "%d:%02d %s".format(h12, minute, if (hour < 12) "AM" else "PM")
+    }
 
     Row(modifier = Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 14.dp)) {
         Column(
@@ -127,9 +136,9 @@ private fun DigitalClock(
                     Spacer(Modifier.height(4.dp))
                 }
                 Text(
-                    text          = "%02d:%02d".format(hour, minute),
+                    text          = timeText,
                     color         = contentColor,
-                    fontSize      = 44.sp,
+                    fontSize      = if (use24HourFormat) 44.sp else 36.sp,
                     fontWeight    = FontWeight.Light,
                     letterSpacing = 1.sp
                 )

--- a/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
@@ -2,6 +2,10 @@ package com.openlauncher.app.ui.widget
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.NightsStay
+import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -10,6 +14,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.openlauncher.app.data.ClockStyle
@@ -41,34 +46,57 @@ fun ClockWidget(
 
     Box(modifier = modifier) {
         when (style) {
-            ClockStyle.DIGITAL -> DigitalClock(calendar, contentColor, subColor)
+            ClockStyle.DIGITAL -> DigitalClock(calendar, contentColor, subColor, accent)
             ClockStyle.ANALOG  -> AnalogClock(calendar, accent, isDayMode)
         }
     }
 }
 
 @Composable
-private fun DigitalClock(cal: Calendar, contentColor: Color, subColor: Color) {
+private fun DigitalClock(cal: Calendar, contentColor: Color, subColor: Color, accent: Color) {
     val hour   = cal.get(Calendar.HOUR_OF_DAY)
     val minute = cal.get(Calendar.MINUTE)
+    val isDaylightHour = hour in 6..17
 
     Column(
-        modifier            = Modifier.fillMaxSize().padding(start = 14.dp, bottom = 14.dp),
-        verticalArrangement = Arrangement.Bottom,
-        horizontalAlignment = Alignment.Start
+        modifier            = Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 14.dp),
+        verticalArrangement = Arrangement.SpaceBetween
     ) {
-        Text(
-            text          = "%02d:%02d".format(hour, minute),
-            color         = contentColor,
-            fontSize      = 48.sp,
-            fontWeight    = androidx.compose.ui.text.font.FontWeight.Light,
-            letterSpacing = 1.sp
-        )
-        Text(
-            text     = buildDateString(cal),
-            color    = subColor,
-            fontSize = 12.sp
-        )
+        // Top row fills the space the plain bottom-anchored layout used to leave empty
+        Row(
+            modifier              = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment     = Alignment.CenterVertically
+        ) {
+            Text(
+                text          = clockTimeLabel(cal),
+                color         = subColor,
+                fontSize      = 9.sp,
+                fontWeight    = FontWeight.Bold,
+                letterSpacing = 2.sp
+            )
+            Icon(
+                imageVector        = if (isDaylightHour) Icons.Default.WbSunny else Icons.Default.NightsStay,
+                contentDescription = null,
+                tint               = accent.copy(alpha = 0.45f),
+                modifier           = Modifier.size(14.dp)
+            )
+        }
+
+        Column(horizontalAlignment = Alignment.Start) {
+            Text(
+                text          = "%02d:%02d".format(hour, minute),
+                color         = contentColor,
+                fontSize      = 44.sp,
+                fontWeight    = FontWeight.Light,
+                letterSpacing = 1.sp
+            )
+            Text(
+                text     = buildDateString(cal),
+                color    = subColor,
+                fontSize = 12.sp
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
@@ -1,6 +1,7 @@
 package com.openlauncher.app.ui.widget
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.NightsStay
@@ -18,18 +19,28 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.openlauncher.app.data.ClockStyle
+import com.openlauncher.app.util.LocationData
+import com.openlauncher.app.util.SunriseSunset
 import kotlinx.coroutines.delay
 import java.util.*
 import kotlin.math.cos
 import kotlin.math.sin
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material.icons.filled.Bluetooth
 
 @Composable
 fun ClockWidget(
     style: ClockStyle,
     accent: Color,
     isDayMode: Boolean = false,
+    location: LocationData? = null,
+    showSunriseSunset: Boolean = true,
+    showQuickToggles: Boolean = true,
+    isEditing: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     var calendar by remember { mutableStateOf(Calendar.getInstance()) }
@@ -46,57 +57,156 @@ fun ClockWidget(
 
     Box(modifier = modifier) {
         when (style) {
-            ClockStyle.DIGITAL -> DigitalClock(calendar, contentColor, subColor, accent)
+            ClockStyle.DIGITAL -> DigitalClock(
+                cal = calendar, contentColor = contentColor, subColor = subColor, accent = accent,
+                location = location, showSunriseSunset = showSunriseSunset,
+                showQuickToggles = showQuickToggles, isDayMode = isDayMode, isEditing = isEditing
+            )
             ClockStyle.ANALOG  -> AnalogClock(calendar, accent, isDayMode)
         }
     }
 }
 
 @Composable
-private fun DigitalClock(cal: Calendar, contentColor: Color, subColor: Color, accent: Color) {
+private fun DigitalClock(
+    cal: Calendar,
+    contentColor: Color,
+    subColor: Color,
+    accent: Color,
+    location: LocationData?,
+    showSunriseSunset: Boolean,
+    showQuickToggles: Boolean,
+    isDayMode: Boolean,
+    isEditing: Boolean
+) {
     val hour   = cal.get(Calendar.HOUR_OF_DAY)
     val minute = cal.get(Calendar.MINUTE)
     val isDaylightHour = hour in 6..17
 
-    Column(
-        modifier            = Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 14.dp),
-        verticalArrangement = Arrangement.SpaceBetween
-    ) {
-        // Top row fills the space the plain bottom-anchored layout used to leave empty
-        Row(
-            modifier              = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment     = Alignment.CenterVertically
+    Row(modifier = Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 14.dp)) {
+        Column(
+            modifier            = Modifier.weight(1f).fillMaxHeight(),
+            verticalArrangement = Arrangement.SpaceBetween
         ) {
-            Text(
-                text          = clockTimeLabel(cal),
-                color         = subColor,
-                fontSize      = 9.sp,
-                fontWeight    = FontWeight.Bold,
-                letterSpacing = 2.sp
-            )
-            Icon(
-                imageVector        = if (isDaylightHour) Icons.Default.WbSunny else Icons.Default.NightsStay,
-                contentDescription = null,
-                tint               = accent.copy(alpha = 0.45f),
-                modifier           = Modifier.size(14.dp)
-            )
+            // Top row fills the space the plain bottom-anchored layout used to leave empty
+            Row(
+                modifier              = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment     = Alignment.CenterVertically
+            ) {
+                Text(
+                    text          = clockTimeLabel(cal),
+                    color         = subColor,
+                    fontSize      = 9.sp,
+                    fontWeight    = FontWeight.Bold,
+                    letterSpacing = 2.sp
+                )
+                Icon(
+                    imageVector        = if (isDaylightHour) Icons.Default.WbSunny else Icons.Default.NightsStay,
+                    contentDescription = null,
+                    tint               = accent.copy(alpha = 0.45f),
+                    modifier           = Modifier.size(14.dp)
+                )
+            }
+
+            // Bottom-anchored — sunrise/sunset (moved here from the Weather panel
+            // to keep that panel from getting crowded) sits directly above the
+            // time, which stays pinned to its original bottom-left spot.
+            Column(horizontalAlignment = Alignment.Start) {
+                if (showSunriseSunset && location != null) {
+                    val (riseMin, setMin) = remember(location.latitude, location.longitude) {
+                        SunriseSunset.localMinutes(location.latitude, location.longitude)
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Icon(Icons.Default.ArrowUpward, null, tint = subColor, modifier = Modifier.size(10.dp))
+                        Text(text = "%02d:%02d".format(riseMin / 60, riseMin % 60), color = subColor, fontSize = 10.sp)
+                        Spacer(Modifier.width(6.dp))
+                        Icon(Icons.Default.ArrowDownward, null, tint = subColor, modifier = Modifier.size(10.dp))
+                        Text(text = "%02d:%02d".format(setMin / 60, setMin % 60), color = subColor, fontSize = 10.sp)
+                    }
+                    Spacer(Modifier.height(4.dp))
+                }
+                Text(
+                    text          = "%02d:%02d".format(hour, minute),
+                    color         = contentColor,
+                    fontSize      = 44.sp,
+                    fontWeight    = FontWeight.Light,
+                    letterSpacing = 1.sp
+                )
+                Text(
+                    text     = buildDateString(cal),
+                    color    = subColor,
+                    fontSize = 12.sp
+                )
+            }
         }
 
-        Column(horizontalAlignment = Alignment.Start) {
-            Text(
-                text          = "%02d:%02d".format(hour, minute),
-                color         = contentColor,
-                fontSize      = 44.sp,
-                fontWeight    = FontWeight.Light,
-                letterSpacing = 1.sp
-            )
-            Text(
-                text     = buildDateString(cal),
-                color    = subColor,
-                fontSize = 12.sp
+        // Right rail — WiFi/Bluetooth stacked portrait-style in the panel's
+        // otherwise-empty right side. DND dropped: not something anyone
+        // actually reaches for on a car head unit.
+        if (showQuickToggles) {
+            Spacer(Modifier.width(10.dp))
+            CompactQuickToggles(
+                accent    = accent,
+                isDayMode = isDayMode,
+                isEditing = isEditing,
+                modifier  = Modifier.fillMaxHeight()
             )
         }
+    }
+}
+
+/**
+ * Icon-only WiFi/Bluetooth rail for the Clock panel's empty right side —
+ * a slimmer sibling of [QuickTogglesWidget] (which is padded for filling
+ * a whole standalone widget cell, not standing in a narrow column).
+ */
+@Composable
+private fun CompactQuickToggles(accent: Color, isDayMode: Boolean, isEditing: Boolean, modifier: Modifier = Modifier) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val wifiManager = remember { context.applicationContext.getSystemService(android.content.Context.WIFI_SERVICE) as? android.net.wifi.WifiManager }
+
+    var wifiOn by remember { mutableStateOf(wifiManager?.isWifiEnabled == true) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            wifiOn = wifiManager?.isWifiEnabled == true
+            delay(2000)
+        }
+    }
+
+    val inactiveTint = if (isDayMode) Color(0xFF999999) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.35f)
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.Default.Wifi,
+            contentDescription = "WiFi",
+            tint = if (wifiOn) accent else inactiveTint,
+            modifier = Modifier
+                .size(18.dp)
+                .clickable(enabled = !isEditing) {
+                    runCatching {
+                        context.startActivity(android.content.Intent(android.provider.Settings.Panel.ACTION_WIFI).addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK))
+                    }.onFailure {
+                        runCatching { context.startActivity(android.content.Intent(android.provider.Settings.ACTION_WIFI_SETTINGS).addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)) }
+                    }
+                }
+        )
+        Spacer(Modifier.height(16.dp))
+        Icon(
+            imageVector = Icons.Default.Bluetooth,
+            contentDescription = "Bluetooth",
+            tint = inactiveTint,
+            modifier = Modifier
+                .size(18.dp)
+                .clickable(enabled = !isEditing) {
+                    runCatching { context.startActivity(android.content.Intent(android.provider.Settings.ACTION_BLUETOOTH_SETTINGS).addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)) }
+                }
+        )
     }
 }
 

--- a/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
@@ -27,8 +27,6 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material.icons.filled.ArrowUpward
-import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.filled.Bluetooth
 
@@ -127,10 +125,10 @@ private fun DigitalClock(
                         SunriseSunset.localMinutes(location.latitude, location.longitude)
                     }
                     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Icon(Icons.Default.ArrowUpward, null, tint = subColor, modifier = Modifier.size(10.dp))
+                        Text(text = "🌅", fontSize = 11.sp) // 🌅 sunrise
                         Text(text = "%02d:%02d".format(riseMin / 60, riseMin % 60), color = subColor, fontSize = 10.sp)
                         Spacer(Modifier.width(6.dp))
-                        Icon(Icons.Default.ArrowDownward, null, tint = subColor, modifier = Modifier.size(10.dp))
+                        Text(text = "🌇", fontSize = 11.sp) // 🌇 sunset
                         Text(text = "%02d:%02d".format(setMin / 60, setMin % 60), color = subColor, fontSize = 10.sp)
                     }
                     Spacer(Modifier.height(4.dp))

--- a/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/ClockWidget.kt
@@ -95,10 +95,11 @@ private fun DigitalClock(
             modifier            = Modifier.weight(1f).fillMaxHeight(),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
-            // Top row fills the space the plain bottom-anchored layout used to leave empty
+            // Icon sits directly beside the label (not SpaceBetween'd across the
+            // whole row) so it stays anchored to its text instead of drifting to
+            // the far edge on wider panels.
             Row(
-                modifier              = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment     = Alignment.CenterVertically
             ) {
                 Text(

--- a/app/src/main/java/com/openlauncher/app/ui/widget/FuelLogWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/FuelLogWidget.kt
@@ -1,0 +1,220 @@
+package com.openlauncher.app.ui.widget
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.LocalGasStation
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.openlauncher.app.data.FuelEntry
+
+private const val KM_PER_MILE = 1.609344
+
+@Composable
+fun FuelLogWidget(
+    entries: List<FuelEntry>,
+    isMetric: Boolean,
+    accent: Color,
+    isDayMode: Boolean = false,
+    isEditing: Boolean = false,
+    onAddEntry: (odometerKm: Double, volume: Double, cost: Double) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val displayColor = if (isDayMode) Color(0xFF111111) else MaterialTheme.colorScheme.onBackground
+    val labelColor    = if (isDayMode) Color(0xFF888888) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.30f)
+    val dimColor      = if (isDayMode) Color(0xFF888888) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+
+    var showAddDialog by remember { mutableStateOf(false) }
+
+    val sorted   = entries.sortedBy { it.timestampMs }
+    val last     = sorted.lastOrNull()
+    val previous = if (sorted.size >= 2) sorted[sorted.size - 2] else null
+
+    // Distance/efficiency since the prior fill-up (only when there's a pair to diff)
+    val distanceKm  = if (last != null && previous != null) last.odometerKm - previous.odometerKm else null
+    val efficiency  = if (distanceKm != null && distanceKm > 0 && last!!.volume > 0) {
+        if (isMetric) (last.volume / distanceKm) * 100.0            // L/100km
+        else distanceKm / KM_PER_MILE / last.volume                  // MPG
+    } else null
+    val costPerDist = if (distanceKm != null && distanceKm > 0 && last != null) {
+        if (isMetric) last.cost / distanceKm else last.cost / (distanceKm / KM_PER_MILE)
+    } else null
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 14.dp, end = 14.dp, top = 22.dp, bottom = 10.dp),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            if (last == null) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Icon(Icons.Default.LocalGasStation, null, tint = dimColor, modifier = Modifier.size(20.dp))
+                    Spacer(Modifier.height(4.dp))
+                    Text("NO FILL-UPS LOGGED", color = dimColor, fontSize = 8.sp, letterSpacing = 1.sp, fontFamily = FontFamily.Monospace)
+                }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column(verticalArrangement = Arrangement.SpaceBetween) {
+                        Text("EFFICIENCY", color = labelColor, fontSize = 6.5.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold, letterSpacing = 0.5.sp)
+                        Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(3.dp)) {
+                            Text(
+                                text = efficiency?.let { "%.1f".format(it) } ?: "--.-",
+                                color = displayColor, fontSize = 22.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = if (isMetric) "L/100" else "MPG",
+                                color = displayColor, fontSize = 8.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold,
+                                modifier = Modifier.padding(bottom = 3.dp)
+                            )
+                        }
+                    }
+                    Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.SpaceBetween) {
+                        Text("LAST FILL-UP", color = labelColor, fontSize = 6.5.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold, letterSpacing = 0.5.sp)
+                        Column(horizontalAlignment = Alignment.End) {
+                            Text("%.2f".format(last.cost), color = displayColor, fontSize = 14.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold)
+                            Text(
+                                text = costPerDist?.let { "%.3f/%s".format(it, if (isMetric) "km" else "mi") } ?: "-- / fill-up",
+                                color = dimColor, fontSize = 7.sp, fontFamily = FontFamily.Monospace
+                            )
+                        }
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .height(26.dp)
+                        .clip(RoundedCornerShape(3.dp))
+                        .background(accent.copy(alpha = 0.12f))
+                        .border(1.dp, accent.copy(alpha = 0.5f), RoundedCornerShape(3.dp))
+                        .clickable(enabled = !isEditing) { showAddDialog = true }
+                        .padding(horizontal = 10.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Icon(Icons.Default.Add, null, tint = accent, modifier = Modifier.size(12.dp))
+                        Text("LOG FILL-UP", color = accent, fontSize = 8.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold, letterSpacing = 0.5.sp)
+                    }
+                }
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        AddFuelEntryDialog(
+            isMetric  = isMetric,
+            accent    = accent,
+            isDayMode = isDayMode,
+            onDismiss = { showAddDialog = false },
+            onConfirm = { odometer, volume, cost ->
+                val odometerKm = if (isMetric) odometer else odometer * KM_PER_MILE
+                onAddEntry(odometerKm, volume, cost)
+                showAddDialog = false
+            }
+        )
+    }
+}
+
+@Composable
+private fun AddFuelEntryDialog(
+    isMetric: Boolean,
+    accent: Color,
+    isDayMode: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (odometer: Double, volume: Double, cost: Double) -> Unit
+) {
+    var odometerText by remember { mutableStateOf("") }
+    var volumeText   by remember { mutableStateOf("") }
+    var costText     by remember { mutableStateOf("") }
+
+    val dialogBg   = if (isDayMode) Color(0xFFFFFFFF) else MaterialTheme.colorScheme.background
+    val dialogText = if (isDayMode) Color(0xFF111111) else MaterialTheme.colorScheme.onBackground
+    val cancelColor = if (isDayMode) Color(0xFF6C757D) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+
+    val odometer = odometerText.toDoubleOrNull()
+    val volume   = volumeText.toDoubleOrNull()
+    val cost     = costText.toDoubleOrNull()
+    val valid    = odometer != null && odometer > 0 && volume != null && volume > 0 && cost != null && cost >= 0
+
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(4.dp))
+                .background(dialogBg)
+                .padding(20.dp)
+                .widthIn(min = 280.dp, max = 380.dp)
+        ) {
+            Text("LOG FILL-UP", color = dialogText, fontSize = 11.sp, letterSpacing = 2.sp, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(16.dp))
+
+            OutlinedTextField(
+                value = odometerText,
+                onValueChange = { odometerText = it },
+                label = { Text(if (isMetric) "ODOMETER (KM)" else "ODOMETER (MI)", fontSize = 10.sp) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(10.dp))
+            OutlinedTextField(
+                value = volumeText,
+                onValueChange = { volumeText = it },
+                label = { Text(if (isMetric) "VOLUME (LITERS)" else "VOLUME (GALLONS)", fontSize = 10.sp) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(10.dp))
+            OutlinedTextField(
+                value = costText,
+                onValueChange = { costText = it },
+                label = { Text("TOTAL COST", fontSize = 10.sp) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(20.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onDismiss) {
+                    Text("CANCEL", color = cancelColor, fontSize = 11.sp, letterSpacing = 1.sp)
+                }
+                TextButton(
+                    enabled = valid,
+                    onClick = { if (valid) onConfirm(odometer!!, volume!!, cost!!) }
+                ) {
+                    Text("SAVE", color = if (valid) accent else cancelColor, fontSize = 11.sp, letterSpacing = 1.sp)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/openlauncher/app/ui/widget/LocationWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/LocationWidget.kt
@@ -1,0 +1,99 @@
+package com.openlauncher.app.ui.widget
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GpsFixed
+import androidx.compose.material.icons.filled.GpsOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.openlauncher.app.util.LocationData
+import kotlin.math.absoluteValue
+
+@Composable
+fun LocationWidget(
+    location: LocationData?,
+    placeName: String? = null,
+    accent: Color,
+    isDayMode: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    val displayColor = if (isDayMode) Color(0xFF111111) else MaterialTheme.colorScheme.onBackground
+    val labelColor   = if (isDayMode) Color(0xFF888888) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.30f)
+    val dimColor     = if (isDayMode) Color(0xFF888888) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+
+    Box(modifier = modifier.fillMaxSize()) {
+        if (location == null) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Icon(Icons.Default.GpsOff, null, tint = dimColor, modifier = Modifier.size(22.dp))
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    "NO GPS FIX", color = dimColor, fontSize = 9.sp,
+                    fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold, letterSpacing = 1.5.sp
+                )
+            }
+        } else {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 14.dp),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        "LIVE LOCATION", color = labelColor, fontSize = 9.sp,
+                        fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold, letterSpacing = 1.5.sp
+                    )
+                    Icon(Icons.Default.GpsFixed, null, tint = accent.copy(alpha = 0.7f), modifier = Modifier.size(14.dp))
+                }
+
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    if (placeName != null) {
+                        Text(
+                            text = placeName,
+                            color = displayColor, fontSize = 17.sp, fontWeight = FontWeight.Bold,
+                            maxLines = 1, overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = "${formatCoordinate(location.latitude, isLat = true)}  ${formatCoordinate(location.longitude, isLat = false)}",
+                            color = dimColor, fontSize = 9.sp, fontFamily = FontFamily.Monospace
+                        )
+                    } else {
+                        Text(
+                            text = formatCoordinate(location.latitude, isLat = true),
+                            color = displayColor, fontSize = 18.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = formatCoordinate(location.longitude, isLat = false),
+                            color = displayColor, fontSize = 18.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+
+                Text(
+                    text = "±${location.accuracy.toInt()}m ACCURACY",
+                    color = dimColor, fontSize = 8.sp, fontFamily = FontFamily.Monospace, letterSpacing = 0.5.sp
+                )
+            }
+        }
+    }
+}
+
+private fun formatCoordinate(value: Double, isLat: Boolean): String {
+    val hemisphere = if (isLat) (if (value >= 0) "N" else "S") else (if (value >= 0) "E" else "W")
+    return "%.4f° %s".format(value.absoluteValue, hemisphere)
+}

--- a/app/src/main/java/com/openlauncher/app/ui/widget/NowPlayingWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/NowPlayingWidget.kt
@@ -612,61 +612,55 @@ private fun StandardMinimalPlayer(
                 }
             }
 
-            // Draw Album Art as background with smooth blur overlay if present
+            // Album art as a contained thumbnail (Spotify's own treatment), not a
+            // full-bleed cropped background — that read as oversized/distracting
+            // next to how Spotify's own player actually presents Canvas art.
             val hasAlbumArt = nonNullState.albumArt != null
-            val useDarkTheme = hasAlbumArt || !isDayMode
-
-            val currentTextColor = if (hasAlbumArt) Color.White else if (isDayMode) Color(0xFF111111) else MaterialTheme.colorScheme.onBackground
-            val currentSubTextColor = if (hasAlbumArt) Color.White.copy(alpha = 0.6f) else if (isDayMode) Color(0xFF666666) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
-            val currentProgressColor = if (useDarkTheme) accent else if (isDayMode) Color(0xFF111111) else accent
+            val currentTextColor = if (isDayMode) Color(0xFF111111) else MaterialTheme.colorScheme.onBackground
+            val currentSubTextColor = if (isDayMode) Color(0xFF666666) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+            val currentProgressColor = if (isDayMode) Color(0xFF111111) else accent
             val currentProgressTrack = currentTextColor.copy(alpha = 0.15f)
             val currentIconColor = currentTextColor.copy(alpha = 0.75f)
-            val currentPlayBgColor = if (useDarkTheme) accent.copy(alpha = 0.9f) else if (isDayMode) Color(0xFF111111) else accent.copy(alpha = 0.9f)
-            val currentPlayIconColor = if (useDarkTheme) Color.Black else Color.White
-
-            if (hasAlbumArt) {
-                // Prefer the full-resolution art URI when the source app provides
-                // one — the metadata bitmap is often a downscaled notification
-                // thumbnail that looks soft stretched across the widget. Falls back
-                // to the bitmap if the URI fails to load, and renders with high
-                // filter quality so upscaling stays smooth either way.
-                coil.compose.AsyncImage(
-                    model = nonNullState.artUri ?: nonNullState.albumArt,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    filterQuality = androidx.compose.ui.graphics.FilterQuality.High,
-                    error = nonNullState.albumArt?.let {
-                        androidx.compose.ui.graphics.painter.BitmapPainter(it.asImageBitmap())
-                    },
-                    modifier = Modifier.fillMaxSize()
-                )
-                // 25% dimming layer overlay
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(Color.Black.copy(alpha = 0.25f))
-                )
-            }
+            val currentPlayBgColor = if (isDayMode) Color(0xFF111111) else accent.copy(alpha = 0.9f)
+            val currentPlayIconColor = if (isDayMode) Color.White else Color.Black
 
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 14.dp, vertical = 10.dp),
-                verticalArrangement = Arrangement.SpaceBetween
+                    .padding(horizontal = 14.dp, vertical = 10.dp)
             ) {
-                // Track info (top — clickable to open app)
+                // Track info — bigger thumbnail, centered as the visual focus of the
+                // tile (not corner-tucked), but still bounded rather than full-bleed.
                 Column(
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
                     modifier = Modifier
-                        .padding(top = 16.dp)
+                        .weight(1f)
+                        .fillMaxWidth()
                         .let { if (!isEditing) it.clickable { onTapToOpenApp() } else it }
                 ) {
+                    if (hasAlbumArt) {
+                        coil.compose.AsyncImage(
+                            model = nonNullState.artUri ?: nonNullState.albumArt,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            filterQuality = androidx.compose.ui.graphics.FilterQuality.High,
+                            error = nonNullState.albumArt?.let {
+                                androidx.compose.ui.graphics.painter.BitmapPainter(it.asImageBitmap())
+                            },
+                            modifier = Modifier
+                                .size(72.dp)
+                                .clip(RoundedCornerShape(8.dp))
+                        )
+                        Spacer(Modifier.height(8.dp))
+                    }
                     Text(
                         text = nonNullState.title,
                         style = MaterialTheme.typography.titleMedium,
                         color = currentTextColor,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                         fontSize = 14.sp
                     )
                     Text(
@@ -675,6 +669,7 @@ private fun StandardMinimalPlayer(
                         color = currentSubTextColor,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                         fontSize = 11.sp
                     )
                 }

--- a/app/src/main/java/com/openlauncher/app/ui/widget/NowPlayingWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/NowPlayingWidget.kt
@@ -168,7 +168,7 @@ fun NowPlayingWidget(
                         Image(
                             bitmap = appIcon,
                             contentDescription = null,
-                            modifier = Modifier.size(48.dp).clip(RoundedCornerShape(10.dp))
+                            modifier = Modifier.size(40.dp).clip(RoundedCornerShape(9.dp))
                         )
                     }
                     if (isBluetoothRoute) {
@@ -696,7 +696,7 @@ private fun StandardMinimalPlayer(
                                 androidx.compose.ui.graphics.painter.BitmapPainter(it.asImageBitmap())
                             },
                             modifier = Modifier
-                                .size(160.dp)
+                                .size(180.dp)
                                 .clip(RoundedCornerShape(12.dp))
                         )
                         Spacer(Modifier.height(10.dp))

--- a/app/src/main/java/com/openlauncher/app/ui/widget/NowPlayingWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/NowPlayingWidget.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MusicNote
@@ -40,6 +41,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.graphics.drawable.toBitmap
 import com.openlauncher.app.model.NowPlayingState
 import com.openlauncher.app.service.MediaListenerService
 import kotlin.math.abs
@@ -68,7 +70,8 @@ fun NowPlayingWidget(
     onRadioCycleFm: () -> Unit = {},
     onRadioSwitchAm: () -> Unit = {},
     onRadioTune: (band: String, freq: Float) -> Unit = { _, _ -> },
-    onAssignRadio: () -> Unit = {}
+    onAssignRadio: () -> Unit = {},
+    showSourceBadge: Boolean = true
 ) {
     val context     = LocalContext.current
     val isConnected by MediaListenerService.isConnected.collectAsState()
@@ -134,6 +137,50 @@ fun NowPlayingWidget(
                 onTapToOpenApp = onTapToOpenApp,
                 modifier = Modifier.fillMaxSize()
             )
+        }
+
+        // 1b. SOURCE APP BADGE (Top-Left, below the "NOW PLAYING" label the
+        // parent HomeScreen draws at TopStart/padding(10,7)) — which app is
+        // playing, plus a Bluetooth glyph when audio is routed there. Useful
+        // mainly because different source apps behave differently (e.g. the
+        // hardware radio app drops playback when backgrounded).
+        if (showSourceBadge && hasContent && selectedSource != "FM/AM Radio") {
+            val sourcePackage = state?.controller?.packageName
+            if (!sourcePackage.isNullOrEmpty()) {
+                val appIcon = remember(sourcePackage) {
+                    runCatching { context.packageManager.getApplicationIcon(sourcePackage).toBitmap().asImageBitmap() }.getOrNull()
+                }
+                var isBluetoothRoute by remember { mutableStateOf(false) }
+                LaunchedEffect(Unit) {
+                    while (true) {
+                        isBluetoothRoute = isAudioRoutedToBluetooth(context)
+                        delay(2000)
+                    }
+                }
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(start = 10.dp, top = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    if (appIcon != null) {
+                        Image(
+                            bitmap = appIcon,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp).clip(RoundedCornerShape(10.dp))
+                        )
+                    }
+                    if (isBluetoothRoute) {
+                        Icon(
+                            imageVector = Icons.Default.Bluetooth,
+                            contentDescription = "Bluetooth audio",
+                            tint = (if (isDayMode) Color(0xFF3B7FD1) else accent).copy(alpha = 0.8f),
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
+            }
         }
 
         // 2. FLOATING MULTI-SOURCE SELECTOR (Top-Right, always overlayed)
@@ -649,10 +696,10 @@ private fun StandardMinimalPlayer(
                                 androidx.compose.ui.graphics.painter.BitmapPainter(it.asImageBitmap())
                             },
                             modifier = Modifier
-                                .size(72.dp)
-                                .clip(RoundedCornerShape(8.dp))
+                                .size(160.dp)
+                                .clip(RoundedCornerShape(12.dp))
                         )
-                        Spacer(Modifier.height(8.dp))
+                        Spacer(Modifier.height(10.dp))
                     }
                     Text(
                         text = nonNullState.title,
@@ -729,5 +776,21 @@ private fun StandardMinimalPlayer(
 private fun formatMs(ms: Long): String {
     val s = ms / 1000
     return "%d:%02d".format(s / 60, s % 60)
+}
+
+// getDevices() reports audio routing only — no BLUETOOTH_CONNECT permission
+// needed (that's only required to read a device's *name*, which this skips).
+private fun isAudioRoutedToBluetooth(context: android.content.Context): Boolean {
+    if (android.os.Build.VERSION.SDK_INT < 23) return false
+    val am = context.getSystemService(android.content.Context.AUDIO_SERVICE) as? android.media.AudioManager ?: return false
+    return runCatching {
+        am.getDevices(android.media.AudioManager.GET_DEVICES_OUTPUTS).any { d ->
+            d.type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
+                (android.os.Build.VERSION.SDK_INT >= 31 && (
+                    d.type == android.media.AudioDeviceInfo.TYPE_BLE_HEADSET ||
+                    d.type == android.media.AudioDeviceInfo.TYPE_BLE_SPEAKER
+                ))
+        }
+    }.getOrDefault(false)
 }
 

--- a/app/src/main/java/com/openlauncher/app/ui/widget/QuickTogglesWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/QuickTogglesWidget.kt
@@ -1,0 +1,175 @@
+package com.openlauncher.app.ui.widget
+
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.net.wifi.WifiManager
+import android.provider.Settings
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bluetooth
+import androidx.compose.material.icons.filled.DoNotDisturbOn
+import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * WiFi/Bluetooth/DND access from the home grid instead of Android's settings menus —
+ * mainly so a passenger (or driver at a stoplight) can pair a phone or silence
+ * notifications without hunting through several settings screens.
+ *
+ * WiFi and Bluetooth open the OS's own panel/settings screen rather than toggling
+ * directly: apps can no longer flip radios programmatically as of API 29+ (WiFi) and
+ * 31+ (Bluetooth) — this launches the real, permission-safe UI instead of silently
+ * no-op'ing. DND is toggled directly since NotificationManager still allows that,
+ * gated on the one-time Notification Policy Access grant.
+ */
+@Composable
+fun QuickTogglesWidget(
+    accent: Color,
+    isDayMode: Boolean = false,
+    isEditing: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    val wifiManager = remember { context.applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager }
+    val notificationManager = remember { context.applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager }
+
+    var wifiOn by remember { mutableStateOf(wifiManager?.isWifiEnabled == true) }
+    var dndOn  by remember {
+        mutableStateOf(
+            notificationManager?.let {
+                it.isNotificationPolicyAccessGranted &&
+                    it.currentInterruptionFilter == NotificationManager.INTERRUPTION_FILTER_NONE
+            } ?: false
+        )
+    }
+
+    // Cheap poll so the tiles reflect state changed elsewhere (e.g. the WiFi panel)
+    LaunchedEffect(Unit) {
+        while (true) {
+            wifiOn = wifiManager?.isWifiEnabled == true
+            dndOn = notificationManager?.let {
+                it.isNotificationPolicyAccessGranted &&
+                    it.currentInterruptionFilter == NotificationManager.INTERRUPTION_FILTER_NONE
+            } ?: false
+            kotlinx.coroutines.delay(2000)
+        }
+    }
+
+    fun openWifiPanel() {
+        runCatching {
+            context.startActivity(Intent(Settings.Panel.ACTION_WIFI).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }.onFailure {
+            runCatching { context.startActivity(Intent(Settings.ACTION_WIFI_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) }
+        }
+    }
+
+    fun openBluetoothSettings() {
+        runCatching {
+            context.startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
+    }
+
+    fun toggleDnd() {
+        val nm = notificationManager ?: return
+        if (!nm.isNotificationPolicyAccessGranted) {
+            runCatching {
+                context.startActivity(
+                    Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                )
+            }
+            return
+        }
+        val turningOn = nm.currentInterruptionFilter != NotificationManager.INTERRUPTION_FILTER_NONE
+        runCatching {
+            nm.setInterruptionFilter(
+                if (turningOn) NotificationManager.INTERRUPTION_FILTER_NONE
+                else NotificationManager.INTERRUPTION_FILTER_ALL
+            )
+        }
+        dndOn = turningOn
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 10.dp, vertical = 18.dp),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ToggleTile(
+            icon = Icons.Default.Wifi, label = "WIFI", active = wifiOn,
+            accent = accent, isDayMode = isDayMode,
+            onClick = { if (!isEditing) openWifiPanel() }
+        )
+        ToggleTile(
+            icon = Icons.Default.Bluetooth, label = "PAIR", active = false,
+            accent = accent, isDayMode = isDayMode,
+            onClick = { if (!isEditing) openBluetoothSettings() }
+        )
+        ToggleTile(
+            icon = Icons.Default.DoNotDisturbOn, label = "DND", active = dndOn,
+            accent = accent, isDayMode = isDayMode,
+            onClick = { if (!isEditing) toggleDnd() }
+        )
+    }
+}
+
+@Composable
+private fun ToggleTile(
+    icon: ImageVector,
+    label: String,
+    active: Boolean,
+    accent: Color,
+    isDayMode: Boolean,
+    onClick: () -> Unit
+) {
+    val inactiveTint = if (isDayMode) Color(0xFF888888) else MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f)
+    val labelColor    = if (active) accent else inactiveTint
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 4.dp)
+    ) {
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .size(34.dp)
+                .clip(androidx.compose.foundation.shape.CircleShape)
+                .background(if (active) accent.copy(alpha = 0.15f) else Color.Transparent)
+                .border(1.dp, if (active) accent.copy(alpha = 0.6f) else inactiveTint.copy(alpha = 0.4f), androidx.compose.foundation.shape.CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(icon, null, tint = if (active) accent else inactiveTint, modifier = Modifier.size(18.dp))
+        }
+        Text(
+            text = label,
+            color = labelColor,
+            fontSize = 7.sp,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 0.5.sp
+        )
+    }
+}

--- a/app/src/main/java/com/openlauncher/app/ui/widget/WeatherWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/WeatherWidget.kt
@@ -1,16 +1,21 @@
 package com.openlauncher.app.ui.widget
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.openlauncher.app.model.WeatherState
+import com.openlauncher.app.util.LocationData
+import kotlin.math.absoluteValue
 
 @Composable
 fun WeatherWidget(
@@ -18,6 +23,8 @@ fun WeatherWidget(
     accent: Color,
     metric: Boolean,
     isDayMode: Boolean = false,
+    location: LocationData? = null,
+    placeName: String? = null,
     modifier: Modifier = Modifier
 ) {
     val contentColor = if (isDayMode) Color(0xFF111111) else MaterialTheme.colorScheme.onBackground
@@ -26,29 +33,88 @@ fun WeatherWidget(
     Box(modifier = modifier) {
         if (state != null) {
             Column(
-                modifier            = Modifier.fillMaxSize().padding(start = 14.dp, bottom = 14.dp),
-                verticalArrangement = Arrangement.Bottom,
-                horizontalAlignment = Alignment.Start
+                modifier            = Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 14.dp),
+                verticalArrangement = Arrangement.SpaceBetween
             ) {
-                Text(
-                    text     = state.conditionIcon,
-                    fontSize = 34.sp
-                )
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text       = state.temperatureDisplay(metric),
-                    color      = contentColor,
-                    fontSize   = 32.sp,
-                    fontWeight = FontWeight.Light,
-                    letterSpacing = 1.sp
-                )
-                Text(
-                    text          = state.conditionLabel.uppercase(),
-                    color         = subColor,
-                    fontSize      = 9.sp,
-                    letterSpacing = 1.sp
-                )
+                // Current conditions
+                Row(
+                    verticalAlignment     = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Text(text = state.conditionIcon, fontSize = 30.sp)
+                    Column {
+                        Text(
+                            text          = state.temperatureDisplay(metric),
+                            color         = contentColor,
+                            fontSize      = 28.sp,
+                            fontWeight    = FontWeight.Light,
+                            letterSpacing = 1.sp
+                        )
+                        Text(
+                            text          = state.conditionLabel.uppercase(),
+                            color         = subColor,
+                            fontSize      = 9.sp,
+                            letterSpacing = 1.sp
+                        )
+                        if (placeName != null) {
+                            Text(
+                                text          = placeName,
+                                color         = subColor.copy(alpha = 0.8f),
+                                fontSize      = 8.sp,
+                                letterSpacing = 0.3.sp,
+                                maxLines      = 1,
+                                overflow      = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                            )
+                        } else if (location != null) {
+                            Text(
+                                text = "%.2f°%s %.2f°%s".format(
+                                    location.latitude.absoluteValue, if (location.latitude >= 0) "N" else "S",
+                                    location.longitude.absoluteValue, if (location.longitude >= 0) "E" else "W"
+                                ),
+                                color         = subColor.copy(alpha = 0.7f),
+                                fontSize      = 7.sp,
+                                letterSpacing = 0.3.sp
+                            )
+                        }
+                    }
+                }
+
+                // Next few hours — scrolls if the widget's narrower than the whole strip,
+                // so resizing it wider (e.g. spanning 2 columns) just reveals more of it.
+                if (state.hourlyForecast.isNotEmpty()) {
+                    LazyRow(
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier              = Modifier.fillMaxWidth()
+                    ) {
+                        items(state.hourlyForecast) { pt ->
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(2.dp)
+                            ) {
+                                Text(
+                                    text          = hourLabel(pt.hour),
+                                    color         = subColor,
+                                    fontSize      = 8.sp,
+                                    fontFamily    = FontFamily.Monospace,
+                                    letterSpacing = 0.5.sp
+                                )
+                                Text(text = pt.conditionIcon, fontSize = 15.sp)
+                                Text(
+                                    text     = pt.temperatureDisplay(metric),
+                                    color    = contentColor,
+                                    fontSize = 10.sp
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
     }
+}
+
+private fun hourLabel(hour24: Int): String {
+    val suffix = if (hour24 < 12) "A" else "P"
+    val h12 = when (hour24 % 12) { 0 -> 12; else -> hour24 % 12 }
+    return "$h12$suffix"
 }

--- a/app/src/main/java/com/openlauncher/app/ui/widget/WeatherWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/WeatherWidget.kt
@@ -76,7 +76,12 @@ fun WeatherWidget(
                                 color         = subColor.copy(alpha = 0.8f),
                                 fontSize      = 12.sp,
                                 letterSpacing = 0.3.sp,
-                                maxLines      = 1,
+                                lineHeight    = 14.sp,
+                                // Wraps to a 2nd line only when the full name doesn't
+                                // fit on one — short names ("Singapore, Kallang") stay
+                                // single-line, long ones ("Singapore, Woodlands South")
+                                // get the space instead of being cut off mid-word.
+                                maxLines      = 2,
                                 overflow      = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                             )
                         } else if (location != null) {

--- a/app/src/main/java/com/openlauncher/app/ui/widget/WeatherWidget.kt
+++ b/app/src/main/java/com/openlauncher/app/ui/widget/WeatherWidget.kt
@@ -25,6 +25,9 @@ fun WeatherWidget(
     isDayMode: Boolean = false,
     location: LocationData? = null,
     placeName: String? = null,
+    showWindSpeed: Boolean = true,
+    showFeelsLike: Boolean = true,
+    showRainChance: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     val contentColor = if (isDayMode) Color(0xFF111111) else MaterialTheme.colorScheme.onBackground
@@ -43,15 +46,26 @@ fun WeatherWidget(
                 ) {
                     Text(text = state.conditionIcon, fontSize = 30.sp)
                     Column {
+                        Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(
+                                text          = state.temperatureDisplay(metric),
+                                color         = contentColor,
+                                fontSize      = 28.sp,
+                                fontWeight    = FontWeight.Light,
+                                letterSpacing = 1.sp
+                            )
+                            if (showFeelsLike && Math.round(state.feelsLikeCelsius) != Math.round(state.temperatureCelsius)) {
+                                Text(
+                                    text     = "feels ${state.feelsLikeDisplay(metric)}",
+                                    color    = subColor,
+                                    fontSize = 10.sp,
+                                    modifier = Modifier.padding(bottom = 3.dp)
+                                )
+                            }
+                        }
                         Text(
-                            text          = state.temperatureDisplay(metric),
-                            color         = contentColor,
-                            fontSize      = 28.sp,
-                            fontWeight    = FontWeight.Light,
-                            letterSpacing = 1.sp
-                        )
-                        Text(
-                            text          = state.conditionLabel.uppercase(),
+                            text          = state.conditionLabel.uppercase() +
+                                (if (showWindSpeed) "  ·  ${state.windspeedDisplay(metric)}" else ""),
                             color         = subColor,
                             fontSize      = 9.sp,
                             letterSpacing = 1.sp
@@ -60,7 +74,7 @@ fun WeatherWidget(
                             Text(
                                 text          = placeName,
                                 color         = subColor.copy(alpha = 0.8f),
-                                fontSize      = 8.sp,
+                                fontSize      = 12.sp,
                                 letterSpacing = 0.3.sp,
                                 maxLines      = 1,
                                 overflow      = androidx.compose.ui.text.style.TextOverflow.Ellipsis
@@ -72,7 +86,7 @@ fun WeatherWidget(
                                     location.longitude.absoluteValue, if (location.longitude >= 0) "E" else "W"
                                 ),
                                 color         = subColor.copy(alpha = 0.7f),
-                                fontSize      = 7.sp,
+                                fontSize      = 10.sp,
                                 letterSpacing = 0.3.sp
                             )
                         }
@@ -104,6 +118,13 @@ fun WeatherWidget(
                                     color    = contentColor,
                                     fontSize = 10.sp
                                 )
+                                if (showRainChance && pt.precipitationChance > 0) {
+                                    Text(
+                                        text     = "${pt.precipitationChance}%",
+                                        color    = if (isDayMode) Color(0xFF3B7FD1) else Color(0xFF6EA8E0),
+                                        fontSize = 7.sp
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/openlauncher/app/util/LocationCompassManager.kt
+++ b/app/src/main/java/com/openlauncher/app/util/LocationCompassManager.kt
@@ -23,8 +23,6 @@ data class LocationData(
     val speedMps: Float = 0f
 )
 
-private const val TWO_MINUTES_MS = 2 * 60 * 1000L
-
 class LocationCompassManager(context: Context) {
 
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
@@ -48,28 +46,6 @@ class LocationCompassManager(context: Context) {
     // the two providers alternate. Track the best-accepted fix instead of
     // blindly taking whichever callback fires most recently.
     private var bestLocation: Location? = null
-
-    private fun isBetterLocation(location: Location, current: Location?): Boolean {
-        if (current == null) return true
-        val timeDeltaMs = location.time - current.time
-        val isSignificantlyNewer = timeDeltaMs > TWO_MINUTES_MS
-        val isSignificantlyOlder = timeDeltaMs < -TWO_MINUTES_MS
-        if (isSignificantlyNewer) return true
-        if (isSignificantlyOlder) return false
-
-        val isNewer = timeDeltaMs > 0
-        val accuracyDelta = location.accuracy - current.accuracy
-        val isMoreAccurate = accuracyDelta < 0
-        val isSignificantlyLessAccurate = accuracyDelta > 200f
-        val isFromSameProvider = location.provider == current.provider
-
-        return when {
-            isMoreAccurate -> true
-            isNewer && accuracyDelta <= 0 -> true
-            isNewer && !isSignificantlyLessAccurate && isFromSameProvider -> true
-            else -> false
-        }
-    }
 
     private val sensorListener = object : SensorEventListener {
         override fun onSensorChanged(event: SensorEvent) {
@@ -99,7 +75,8 @@ class LocationCompassManager(context: Context) {
 
     private val locationListener = object : LocationListener {
         override fun onLocationChanged(loc: Location) {
-            if (!isBetterLocation(loc, bestLocation)) return
+            val best = bestLocation
+            if (!isBetterLocation(loc.time, loc.accuracy, loc.provider, best?.time, best?.accuracy, best?.provider)) return
             bestLocation = loc
 
             _location.value = LocationData(

--- a/app/src/main/java/com/openlauncher/app/util/LocationCompassManager.kt
+++ b/app/src/main/java/com/openlauncher/app/util/LocationCompassManager.kt
@@ -23,6 +23,8 @@ data class LocationData(
     val speedMps: Float = 0f
 )
 
+private const val TWO_MINUTES_MS = 2 * 60 * 1000L
+
 class LocationCompassManager(context: Context) {
 
     private val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
@@ -39,6 +41,35 @@ class LocationCompassManager(context: Context) {
     private var bearingSin   = 0f
     private var bearingCos   = 1f   // initial: pointing north
     private var lastLocationForBearing: Location? = null
+    // Both GPS and Network providers are registered at once (see start()), and
+    // Network fixes (cell/WiFi) can be hundreds of meters coarser than GPS —
+    // without gating, a coarse Network update stomps over a good GPS fix and
+    // the displayed position visibly jumps between neighbourhoods every time
+    // the two providers alternate. Track the best-accepted fix instead of
+    // blindly taking whichever callback fires most recently.
+    private var bestLocation: Location? = null
+
+    private fun isBetterLocation(location: Location, current: Location?): Boolean {
+        if (current == null) return true
+        val timeDeltaMs = location.time - current.time
+        val isSignificantlyNewer = timeDeltaMs > TWO_MINUTES_MS
+        val isSignificantlyOlder = timeDeltaMs < -TWO_MINUTES_MS
+        if (isSignificantlyNewer) return true
+        if (isSignificantlyOlder) return false
+
+        val isNewer = timeDeltaMs > 0
+        val accuracyDelta = location.accuracy - current.accuracy
+        val isMoreAccurate = accuracyDelta < 0
+        val isSignificantlyLessAccurate = accuracyDelta > 200f
+        val isFromSameProvider = location.provider == current.provider
+
+        return when {
+            isMoreAccurate -> true
+            isNewer && accuracyDelta <= 0 -> true
+            isNewer && !isSignificantlyLessAccurate && isFromSameProvider -> true
+            else -> false
+        }
+    }
 
     private val sensorListener = object : SensorEventListener {
         override fun onSensorChanged(event: SensorEvent) {
@@ -68,6 +99,9 @@ class LocationCompassManager(context: Context) {
 
     private val locationListener = object : LocationListener {
         override fun onLocationChanged(loc: Location) {
+            if (!isBetterLocation(loc, bestLocation)) return
+            bestLocation = loc
+
             _location.value = LocationData(
                 latitude  = loc.latitude,
                 longitude = loc.longitude,
@@ -145,5 +179,6 @@ class LocationCompassManager(context: Context) {
         sensorManager.unregisterListener(sensorListener)
         locationManager.removeUpdates(locationListener)
         lastLocationForBearing = null
+        bestLocation = null
     }
 }

--- a/app/src/main/java/com/openlauncher/app/util/LocationQuality.kt
+++ b/app/src/main/java/com/openlauncher/app/util/LocationQuality.kt
@@ -1,0 +1,41 @@
+package com.openlauncher.app.util
+
+const val TWO_MINUTES_MS = 2 * 60 * 1000L
+
+/**
+ * Standard Android "isBetterLocation" heuristic, extracted to operate on plain
+ * primitives rather than android.location.Location — that keeps it a pure
+ * function, unit-testable on the local JVM without Robolectric/instrumentation.
+ *
+ * Prefers a significantly newer fix outright; otherwise prefers a more
+ * accurate one; a same-provider fix wins ties; a much-less-accurate fix from
+ * a different provider is only accepted if the current fix isn't newer.
+ */
+fun isBetterLocation(
+    newTime: Long,
+    newAccuracy: Float,
+    newProvider: String?,
+    currentTime: Long?,
+    currentAccuracy: Float?,
+    currentProvider: String?
+): Boolean {
+    if (currentTime == null || currentAccuracy == null) return true
+
+    val timeDeltaMs = newTime - currentTime
+    val isSignificantlyNewer = timeDeltaMs > TWO_MINUTES_MS
+    val isSignificantlyOlder = timeDeltaMs < -TWO_MINUTES_MS
+    if (isSignificantlyNewer) return true
+    if (isSignificantlyOlder) return false
+
+    val isNewer = timeDeltaMs > 0
+    val accuracyDelta = newAccuracy - currentAccuracy
+    val isSignificantlyLessAccurate = accuracyDelta > 200f
+    val isFromSameProvider = newProvider == currentProvider
+
+    return when {
+        accuracyDelta < 0 -> true // more accurate
+        isNewer && accuracyDelta <= 0 -> true
+        isNewer && !isSignificantlyLessAccurate && isFromSameProvider -> true
+        else -> false
+    }
+}

--- a/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
+++ b/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
@@ -426,6 +426,11 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
     val weatherError: StateFlow<String?> = _weatherError
 
     private var weatherJob: Job? = null
+    // Stamped on successful fetch only (see fetchWeather/fetchPlaceName) — if these
+    // were stamped on *attempt*, a single failure right at boot (network not up yet)
+    // would lock the panel empty for a full throttle window instead of retrying.
+    private var lastWeatherFetchMs = 0L
+    private var lastPlaceFetchMs = 0L
 
     fun fetchWeather(lat: Double, lon: Double, metric: Boolean) {
         weatherJob?.cancel()
@@ -473,8 +478,12 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
                     )
                 }
                 _weatherError.value = null
+                lastWeatherFetchMs = System.currentTimeMillis()
             } catch (e: Exception) {
                 _weatherError.value = e.message
+                // Deliberately not stamping lastWeatherFetchMs — leaving it at its
+                // last successful value means the next location/minute tick retries
+                // immediately instead of waiting out the full throttle window.
             }
         }
     }
@@ -509,9 +518,13 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
                     com.openlauncher.app.data.LocationDetailLevel.CITY -> broader
                     com.openlauncher.app.data.LocationDetailLevel.REGION -> addr?.state ?: addr?.county ?: broader
                 } ?: resp.displayName?.split(",")?.map { it.trim() }?.take(2)?.joinToString(", ")
-                if (resolved != null) _placeName.value = resolved
+                if (resolved != null) {
+                    _placeName.value = resolved
+                    lastPlaceFetchMs = System.currentTimeMillis()
+                }
             } catch (_: Exception) {
-                // transient network hiccup — leave the last known place name showing
+                // transient network hiccup — leave the last known place name showing,
+                // and leave lastPlaceFetchMs unstamped so the next tick retries soon
             }
         }
     }
@@ -804,19 +817,19 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
         // can cross several neighborhoods in that span, 30 minutes reads stale.
         // The minute ticker covers the parked case where no location updates arrive.
         viewModelScope.launch {
-            var lastWeatherFetchMs = 0L
-            var lastPlaceFetchMs = 0L
             merge(
                 locationMgr.location.filterNotNull(),
                 minuteTicker.mapNotNull { locationMgr.location.value }
             ).collect { loc ->
                 val now = System.currentTimeMillis()
+                // lastWeatherFetchMs/lastPlaceFetchMs are only stamped on a *successful*
+                // fetch (see fetchWeather/fetchPlaceName), so a failed attempt — e.g. right
+                // at boot before the network is up — retries on the next tick instead of
+                // locking the panel empty for the rest of the throttle window.
                 if (now - lastWeatherFetchMs >= 30 * 60 * 1_000L) {
-                    lastWeatherFetchMs = now
                     fetchWeather(loc.latitude, loc.longitude, settings.value.unitSystem.name == "METRIC")
                 }
                 if (now - lastPlaceFetchMs >= 5 * 60 * 1_000L) {
-                    lastPlaceFetchMs = now
                     fetchPlaceName(loc.latitude, loc.longitude)
                 }
             }

--- a/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
+++ b/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
@@ -813,10 +813,12 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
         startVoltageObserver()
         if (hasSzchoicewayMcu) startHardwareRadioObserver()
         // Weather refreshes every 30 minutes (conditions don't change fast enough
-        // to justify more). Place name refreshes every 1 minute — a moving car
-        // can cross several neighborhoods in a few minutes, so this stays close
-        // to real-time; the Nominatim usage policy caps at 1 req/sec, and this
-        // is nowhere near that even at 1-minute intervals.
+        // to justify more). Place name refreshes every 30 seconds while moving —
+        // the Nominatim usage policy caps at 1 req/sec, and this is nowhere near
+        // that even at 30s. Note this only actually tightens the refresh while
+        // driving (GPS fires new fixes every few seconds on movement); parked,
+        // the retry cadence is still bottlenecked by the once-a-minute ticker
+        // below, since a stationary GPS provider won't emit new updates at all.
         // The minute ticker covers the parked case where no location updates arrive.
         viewModelScope.launch {
             merge(
@@ -831,7 +833,7 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
                 if (now - lastWeatherFetchMs >= 30 * 60 * 1_000L) {
                     fetchWeather(loc.latitude, loc.longitude, settings.value.unitSystem.name == "METRIC")
                 }
-                if (now - lastPlaceFetchMs >= 1 * 60 * 1_000L) {
+                if (now - lastPlaceFetchMs >= 30 * 1_000L) {
                     fetchPlaceName(loc.latitude, loc.longitude)
                 }
             }

--- a/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
+++ b/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
@@ -1,11 +1,14 @@
 package com.openlauncher.app.viewmodel
 
 import android.app.Application
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.database.ContentObserver
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import android.os.BatteryManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -219,6 +222,9 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
                 "VITALS"      -> copy(showVitals = true)
                 "TRIP_TRACKER" -> copy(showTripTracker = true)
                 "SOUNDBOARD"  -> copy(showSoundboard = true)
+                "FUEL_LOG"    -> copy(showFuelLog = true)
+                "QUICK_TOGGLES" -> copy(showQuickToggles = true)
+                "LOCATION"    -> copy(showLocation = true)
                 else          -> this
             }
             val idx       = layout.indexOfFirst { it.id == id }
@@ -250,8 +256,54 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
                 "VITALS"      -> copy(showVitals = false)
                 "TRIP_TRACKER" -> copy(showTripTracker = false)
                 "SOUNDBOARD"  -> copy(showSoundboard = false)
+                "FUEL_LOG"    -> copy(showFuelLog = false)
+                "QUICK_TOGGLES" -> copy(showQuickToggles = false)
+                "LOCATION"    -> copy(showLocation = false)
                 else          -> this
             }
+        }
+    }
+
+    fun addFuelEntry(odometerKm: Double, volume: Double, cost: Double) {
+        updateSettings {
+            val entry = com.openlauncher.app.data.FuelEntry(
+                timestampMs = System.currentTimeMillis(),
+                odometerKm  = odometerKm,
+                volume      = volume,
+                cost        = cost,
+                isMetric    = unitSystem == com.openlauncher.app.data.UnitSystem.METRIC
+            )
+            copy(fuelLog = (fuelLog + entry).sortedBy { it.timestampMs })
+        }
+    }
+
+    fun deleteFuelEntry(timestampMs: Long) {
+        updateSettings { copy(fuelLog = fuelLog.filterNot { it.timestampMs == timestampMs }) }
+    }
+
+    /**
+     * Replaces the widget grid wholesale with a named preset (e.g. [splitPanelWidgetLayout])
+     * and syncs each toggleable widget's show-flag to whether it's present in the preset,
+     * so the grid renders exactly the preset with no stray widgets left enabled from before.
+     */
+    fun applyLayoutPreset(preset: List<com.openlauncher.app.data.WidgetConfig>) {
+        updateSettings {
+            val presentIds = preset.map { it.id }.toSet()
+            val withShow = copy(
+                showClock        = "CLOCK" in presentIds,
+                showWeather      = "WEATHER" in presentIds,
+                showNowPlaying   = "NOW_PLAYING" in presentIds,
+                showTelemetry    = "TELEMETRY" in presentIds,
+                showAltimeter    = "ALTIMETER" in presentIds,
+                showSpeedometer  = "SPEEDOMETER" in presentIds,
+                showVitals       = "VITALS" in presentIds,
+                showTripTracker  = "TRIP_TRACKER" in presentIds,
+                showSoundboard   = "SOUNDBOARD" in presentIds
+            )
+            // Keep any widget configs not part of this preset around (disabled) so their
+            // spans/positions aren't lost if the user switches presets again later.
+            val untouched = widgetLayout.filter { it.id !in presentIds }
+            withShow.copy(widgetLayout = preset + untouched)
         }
     }
 
@@ -384,16 +436,64 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
                 // the value through two lossy conversions
                 val resp = WeatherApi.service.getForecast(lat, lon, temperatureUnit = "celsius")
                 resp.currentWeather?.let { cw ->
+                    // Open-Meteo's hourly block is parallel arrays keyed by ISO timestamp
+                    // ("2026-08-12T23:00") — keep only points from the current hour onward
+                    // so the strip reads as "coming up," not partly-past.
+                    val nowIso = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:00", java.util.Locale.US)
+                        .format(java.util.Date())
+                    val hourly = resp.hourly
+                    val forecast = if (hourly != null) {
+                        hourly.time.indices
+                            .filter { hourly.time[it] >= nowIso }
+                            .take(6)
+                            .mapNotNull { i ->
+                                val hourStr = hourly.time.getOrNull(i)?.takeLast(5)?.take(2) ?: return@mapNotNull null
+                                val hour = hourStr.toIntOrNull() ?: return@mapNotNull null
+                                com.openlauncher.app.model.HourlyPoint(
+                                    hour               = hour,
+                                    temperatureCelsius = hourly.temperature2m.getOrNull(i) ?: return@mapNotNull null,
+                                    weatherCode        = hourly.weathercode.getOrNull(i) ?: 0,
+                                    isDay              = hour in 6..17
+                                )
+                            }
+                    } else emptyList()
+
                     _weather.value = WeatherState(
                         temperatureCelsius = cw.temperature,
                         weatherCode       = cw.weathercode,
                         windspeedKmh      = cw.windspeed,
-                        isDay             = cw.isDay == 1
+                        isDay             = cw.isDay == 1,
+                        hourlyForecast    = forecast
                     )
                 }
                 _weatherError.value = null
             } catch (e: Exception) {
                 _weatherError.value = e.message
+            }
+        }
+    }
+
+    // ── Reverse geocoding (coordinates → place name) ───────────────────────────
+    private val _placeName = MutableStateFlow<String?>(null)
+    val placeName: StateFlow<String?> = _placeName
+
+    fun fetchPlaceName(lat: Double, lon: Double) {
+        viewModelScope.launch {
+            try {
+                val resp = com.openlauncher.app.data.NominatimApi.service.reverseGeocode(lat, lon)
+                val addr = resp.address
+                val locality = addr?.suburb ?: addr?.city ?: addr?.town ?: addr?.village ?: addr?.county
+                val state = addr?.state
+                // Keep the previous value on a genuinely empty response rather than
+                // blanking a widget that already had something useful to show.
+                val resolved = when {
+                    locality != null && state != null && state != locality -> "$locality, $state"
+                    locality != null -> locality
+                    else -> resp.displayName?.split(",")?.map { it.trim() }?.take(2)?.joinToString(", ")
+                }
+                if (resolved != null) _placeName.value = resolved
+            } catch (_: Exception) {
+                // transient network hiccup — leave the last known place name showing
             }
         }
     }
@@ -643,29 +743,63 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
+    // ── Voltage ───────────────────────────────────────────────────────────────
+    // Most aftermarket head units have no real internal battery — the vendor ROM
+    // wires the car's 12V input straight into Android's standard battery-voltage
+    // reporting (the same field a phone would use for its own cell), so this reads
+    // through the public BatteryManager API rather than anything unit-specific.
+    private val _voltage = MutableStateFlow<Float?>(null)
+    val voltage: StateFlow<Float?> = _voltage
+
+    private val batteryReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            val millivolts = intent.getIntExtra(BatteryManager.EXTRA_VOLTAGE, -1)
+            // A real car electrical system is never anywhere near 0V while the unit
+            // is on — this unit's standard-Android battery field turned out to be a
+            // meaningless placeholder, not the real CAN-bus-fed voltage sensor its
+            // own status bar reads from. Better to show nothing than a false 0.0V.
+            if (millivolts >= 5000) _voltage.value = millivolts / 1000f
+        }
+    }
+
+    private fun startVoltageObserver() {
+        runCatching {
+            getApplication<Application>().registerReceiver(batteryReceiver, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        }
+    }
+
     override fun onCleared() {
         super.onCleared()
         locationMgr.stop()
         radioObserver?.let { getApplication<Application>().contentResolver.unregisterContentObserver(it) }
         radioObserver = null
+        runCatching { getApplication<Application>().unregisterReceiver(batteryReceiver) }
     }
 
     init {
         loadInstalledApps()
         refreshConnectivity()
+        startVoltageObserver()
         if (hasSzchoicewayMcu) startHardwareRadioObserver()
-        // Fetch weather on first location fix, then every 30 minutes.
+        // Weather refreshes every 30 minutes (conditions don't change fast enough
+        // to justify more). Place name refreshes every 5 minutes — a moving car
+        // can cross several neighborhoods in that span, 30 minutes reads stale.
         // The minute ticker covers the parked case where no location updates arrive.
         viewModelScope.launch {
-            var lastFetchMs = 0L
+            var lastWeatherFetchMs = 0L
+            var lastPlaceFetchMs = 0L
             merge(
                 locationMgr.location.filterNotNull(),
                 minuteTicker.mapNotNull { locationMgr.location.value }
             ).collect { loc ->
                 val now = System.currentTimeMillis()
-                if (now - lastFetchMs >= 30 * 60 * 1_000L) {
-                    lastFetchMs = now
+                if (now - lastWeatherFetchMs >= 30 * 60 * 1_000L) {
+                    lastWeatherFetchMs = now
                     fetchWeather(loc.latitude, loc.longitude, settings.value.unitSystem.name == "METRIC")
+                }
+                if (now - lastPlaceFetchMs >= 5 * 60 * 1_000L) {
+                    lastPlaceFetchMs = now
+                    fetchPlaceName(loc.latitude, loc.longitude)
                 }
             }
         }

--- a/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
+++ b/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
@@ -813,8 +813,10 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
         startVoltageObserver()
         if (hasSzchoicewayMcu) startHardwareRadioObserver()
         // Weather refreshes every 30 minutes (conditions don't change fast enough
-        // to justify more). Place name refreshes every 5 minutes — a moving car
-        // can cross several neighborhoods in that span, 30 minutes reads stale.
+        // to justify more). Place name refreshes every 1 minute — a moving car
+        // can cross several neighborhoods in a few minutes, so this stays close
+        // to real-time; the Nominatim usage policy caps at 1 req/sec, and this
+        // is nowhere near that even at 1-minute intervals.
         // The minute ticker covers the parked case where no location updates arrive.
         viewModelScope.launch {
             merge(
@@ -829,7 +831,7 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
                 if (now - lastWeatherFetchMs >= 30 * 60 * 1_000L) {
                     fetchWeather(loc.latitude, loc.longitude, settings.value.unitSystem.name == "METRIC")
                 }
-                if (now - lastPlaceFetchMs >= 5 * 60 * 1_000L) {
+                if (now - lastPlaceFetchMs >= 1 * 60 * 1_000L) {
                     fetchPlaceName(loc.latitude, loc.longitude)
                 }
             }

--- a/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
+++ b/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
@@ -813,13 +813,14 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
         startVoltageObserver()
         if (hasSzchoicewayMcu) startHardwareRadioObserver()
         // Weather refreshes every 30 minutes (conditions don't change fast enough
-        // to justify more). Place name refreshes every 30 seconds while moving —
-        // the Nominatim usage policy caps at 1 req/sec, and this is nowhere near
-        // that even at 30s. Note this only actually tightens the refresh while
-        // driving (GPS fires new fixes every few seconds on movement); parked,
-        // the retry cadence is still bottlenecked by the once-a-minute ticker
-        // below, since a stationary GPS provider won't emit new updates at all.
-        // The minute ticker covers the parked case where no location updates arrive.
+        // to justify more). Place name refresh interval is user-configurable
+        // (Settings > Location Refresh, 30s/1min/2min/5min — default 30s); the
+        // Nominatim usage policy caps at 1 req/sec, and even the fastest option
+        // is nowhere near that. Note this only actually tightens the refresh
+        // while driving (GPS fires new fixes every few seconds on movement);
+        // parked, the retry cadence is still bottlenecked by the once-a-minute
+        // ticker below, since a stationary GPS provider won't emit new updates
+        // at all — that ticker covers the parked case where no location updates arrive.
         viewModelScope.launch {
             merge(
                 locationMgr.location.filterNotNull(),
@@ -833,7 +834,7 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
                 if (now - lastWeatherFetchMs >= 30 * 60 * 1_000L) {
                     fetchWeather(loc.latitude, loc.longitude, settings.value.unitSystem.name == "METRIC")
                 }
-                if (now - lastPlaceFetchMs >= 30 * 1_000L) {
+                if (now - lastPlaceFetchMs >= settings.value.locationRefreshInterval.millis) {
                     fetchPlaceName(loc.latitude, loc.longitude)
                 }
             }

--- a/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
+++ b/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
@@ -442,28 +442,34 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
                     val nowIso = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:00", java.util.Locale.US)
                         .format(java.util.Date())
                     val hourly = resp.hourly
+                    val currentHourIndices = hourly?.time?.indices
+                        ?.filter { hourly.time[it] >= nowIso }
+                        ?.take(6) ?: emptyList()
                     val forecast = if (hourly != null) {
-                        hourly.time.indices
-                            .filter { hourly.time[it] >= nowIso }
-                            .take(6)
-                            .mapNotNull { i ->
+                        currentHourIndices.mapNotNull { i ->
                                 val hourStr = hourly.time.getOrNull(i)?.takeLast(5)?.take(2) ?: return@mapNotNull null
                                 val hour = hourStr.toIntOrNull() ?: return@mapNotNull null
                                 com.openlauncher.app.model.HourlyPoint(
                                     hour               = hour,
                                     temperatureCelsius = hourly.temperature2m.getOrNull(i) ?: return@mapNotNull null,
                                     weatherCode        = hourly.weathercode.getOrNull(i) ?: 0,
-                                    isDay              = hour in 6..17
+                                    isDay              = hour in 6..17,
+                                    precipitationChance = hourly.precipitationProbability.getOrNull(i) ?: 0
                                 )
                             }
                     } else emptyList()
+                    // First index in the "current hour onward" filter above is the
+                    // present hour itself — reuse it rather than a second lookup.
+                    val feelsLike = currentHourIndices.firstOrNull()
+                        ?.let { hourly?.apparentTemperature?.getOrNull(it) } ?: cw.temperature
 
                     _weather.value = WeatherState(
                         temperatureCelsius = cw.temperature,
                         weatherCode       = cw.weathercode,
                         windspeedKmh      = cw.windspeed,
                         isDay             = cw.isDay == 1,
-                        hourlyForecast    = forecast
+                        hourlyForecast    = forecast,
+                        feelsLikeCelsius  = feelsLike
                     )
                 }
                 _weatherError.value = null

--- a/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
+++ b/app/src/main/java/com/openlauncher/app/viewmodel/LauncherViewModel.kt
@@ -482,15 +482,27 @@ class LauncherViewModel(application: Application) : AndroidViewModel(application
             try {
                 val resp = com.openlauncher.app.data.NominatimApi.service.reverseGeocode(lat, lon)
                 val addr = resp.address
-                val locality = addr?.suburb ?: addr?.city ?: addr?.town ?: addr?.village ?: addr?.county
-                val state = addr?.state
-                // Keep the previous value on a genuinely empty response rather than
-                // blanking a widget that already had something useful to show.
-                val resolved = when {
-                    locality != null && state != null && state != locality -> "$locality, $state"
-                    locality != null -> locality
-                    else -> resp.displayName?.split(",")?.map { it.trim() }?.take(2)?.joinToString(", ")
-                }
+                // Always request finest detail from the API; which fields we actually
+                // show is a client-side choice per locationDetailLevel, so switching
+                // the setting doesn't need a fresh network call.
+                //
+                // "Broader" is the wrapper locality — city, or the nearest thing to
+                // it (falls back to state/county for places with no city field, e.g.
+                // some rural areas). "Fine" is the specific neighbourhood/quarter.
+                // Paired as "Broader, Fine" — e.g. "Singapore, Boon Keng" or
+                // "Johor Bahru, Megah Ria" — not paired with state, which is often
+                // too coarse to add anything (and Singapore has no state at all).
+                val broader = addr?.city ?: addr?.town ?: addr?.village ?: addr?.county ?: addr?.state
+                val fine = addr?.neighbourhood ?: addr?.quarter ?: addr?.suburb ?: addr?.cityDistrict
+                val resolved = when (settings.value.locationDetailLevel) {
+                    com.openlauncher.app.data.LocationDetailLevel.NEIGHBORHOOD -> when {
+                        fine != null && broader != null && fine != broader -> "$broader, $fine"
+                        fine != null -> fine
+                        else -> broader
+                    }
+                    com.openlauncher.app.data.LocationDetailLevel.CITY -> broader
+                    com.openlauncher.app.data.LocationDetailLevel.REGION -> addr?.state ?: addr?.county ?: broader
+                } ?: resp.displayName?.split(",")?.map { it.trim() }?.take(2)?.joinToString(", ")
                 if (resolved != null) _placeName.value = resolved
             } catch (_: Exception) {
                 // transient network hiccup — leave the last known place name showing

--- a/app/src/test/java/com/openlauncher/app/data/ThemePresetsTest.kt
+++ b/app/src/test/java/com/openlauncher/app/data/ThemePresetsTest.kt
@@ -1,0 +1,39 @@
+package com.openlauncher.app.data
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ThemePresetsTest {
+
+    @Test
+    fun `night mode resolves the theme's dark accent, background, and ink`() {
+        val resolved = resolveDashboardTheme("instrument", isDayMode = false)
+        assertEquals(Color(0xFFFFA23DL), resolved?.accent)
+        assertEquals(Color(0xFF14100AL), resolved?.background)
+        assertEquals(Color(0xFFF3ECDDL), resolved?.ink)
+    }
+
+    @Test
+    fun `day mode resolves the theme's light accent and background, with no ink override`() {
+        val resolved = resolveDashboardTheme("instrument", isDayMode = true)
+        assertEquals(Color(0xFF1F2A44L), resolved?.accent)
+        assertEquals(Color(0xFFF0E6D2L), resolved?.background)
+        assertNull(resolved?.ink)
+    }
+
+    @Test
+    fun `every preset resolves in both day and night mode`() {
+        DASHBOARD_THEMES.forEach { theme ->
+            assertEquals(theme.id, resolveDashboardTheme(theme.id, isDayMode = false)?.let { theme.id })
+            assertEquals(theme.id, resolveDashboardTheme(theme.id, isDayMode = true)?.let { theme.id })
+        }
+    }
+
+    @Test
+    fun `an unrecognized theme id (including 'custom') resolves to null`() {
+        assertNull(resolveDashboardTheme("custom", isDayMode = false))
+        assertNull(resolveDashboardTheme("not-a-real-theme", isDayMode = true))
+    }
+}

--- a/app/src/test/java/com/openlauncher/app/data/WidgetLayoutTest.kt
+++ b/app/src/test/java/com/openlauncher/app/data/WidgetLayoutTest.kt
@@ -1,0 +1,49 @@
+package com.openlauncher.app.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WidgetLayoutTest {
+
+    @Test
+    fun `moving to a free cell just relocates it, others untouched`() {
+        val layout = listOf(
+            WidgetConfig("A", gridX = 0, gridY = 0),
+            WidgetConfig("B", gridX = 1, gridY = 0)
+        )
+        val result = computeWidgetMove(layout, movingId = "A", targetX = 2, targetY = 1)
+
+        val a = result.find { it.id == "A" }!!
+        val b = result.find { it.id == "B" }!!
+        assertEquals(2, a.gridX); assertEquals(1, a.gridY)
+        assertEquals(1, b.gridX); assertEquals(0, b.gridY) // unchanged
+    }
+
+    @Test
+    fun `moving onto an occupied cell displaces the occupant to a free one`() {
+        val layout = listOf(
+            WidgetConfig("A", gridX = 0, gridY = 0),
+            WidgetConfig("B", gridX = 1, gridY = 0)
+        )
+        val result = computeWidgetMove(layout, movingId = "A", targetX = 1, targetY = 0)
+
+        val a = result.find { it.id == "A" }!!
+        val b = result.find { it.id == "B" }!!
+        assertEquals(1, a.gridX); assertEquals(0, a.gridY) // moved widget gets its requested spot
+        // Displaced widget must land somewhere that doesn't overlap the mover,
+        // and stay within the grid.
+        assertTrue(b.gridX != a.gridX || b.gridY != a.gridY)
+        assertTrue(b.gridX in 0 until GRID_COLS && b.gridY in 0 until GRID_ROWS)
+    }
+
+    @Test
+    fun `target position is clamped to stay within the grid`() {
+        val layout = listOf(WidgetConfig("A", gridX = 0, gridY = 0, spanX = 2, spanY = 1))
+        val result = computeWidgetMove(layout, movingId = "A", targetX = 99, targetY = 99)
+
+        val a = result.find { it.id == "A" }!!
+        assertTrue(a.gridX <= GRID_COLS - a.spanX)
+        assertTrue(a.gridY <= GRID_ROWS - a.spanY)
+    }
+}

--- a/app/src/test/java/com/openlauncher/app/util/LocationQualityTest.kt
+++ b/app/src/test/java/com/openlauncher/app/util/LocationQualityTest.kt
@@ -1,0 +1,61 @@
+package com.openlauncher.app.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocationQualityTest {
+
+    @Test
+    fun `first fix is always accepted`() {
+        assertTrue(isBetterLocation(1000L, 50f, "gps", null, null, null))
+    }
+
+    @Test
+    fun `a much coarser Network fix does not override a fresh accurate GPS fix`() {
+        // This is the exact bug reported live: GPS gives an accurate fix, then
+        // Network fires moments later with a far coarser one and used to stomp
+        // over it unconditionally.
+        val accepted = isBetterLocation(
+            newTime = 1_005_000L, newAccuracy = 800f, newProvider = "network",
+            currentTime = 1_000_000L, currentAccuracy = 15f, currentProvider = "gps"
+        )
+        assertFalse(accepted)
+    }
+
+    @Test
+    fun `a more accurate fix from either provider is accepted`() {
+        val accepted = isBetterLocation(
+            newTime = 1_005_000L, newAccuracy = 10f, newProvider = "network",
+            currentTime = 1_000_000L, currentAccuracy = 15f, currentProvider = "gps"
+        )
+        assertTrue(accepted)
+    }
+
+    @Test
+    fun `same-provider continuity accepts a newer, not-much-worse fix`() {
+        val accepted = isBetterLocation(
+            newTime = 1_005_000L, newAccuracy = 20f, newProvider = "gps",
+            currentTime = 1_000_000L, currentAccuracy = 15f, currentProvider = "gps"
+        )
+        assertTrue(accepted)
+    }
+
+    @Test
+    fun `a significantly newer fix is accepted even if coarser`() {
+        val accepted = isBetterLocation(
+            newTime = 1_000_000L + TWO_MINUTES_MS + 1L, newAccuracy = 900f, newProvider = "network",
+            currentTime = 1_000_000L, currentAccuracy = 10f, currentProvider = "gps"
+        )
+        assertTrue(accepted)
+    }
+
+    @Test
+    fun `a significantly older fix is rejected outright`() {
+        val accepted = isBetterLocation(
+            newTime = 1_000_000L - TWO_MINUTES_MS - 1L, newAccuracy = 5f, newProvider = "gps",
+            currentTime = 1_000_000L, currentAccuracy = 900f, currentProvider = "network"
+        )
+        assertFalse(accepted)
+    }
+}

--- a/app/src/test/java/com/openlauncher/app/util/SunriseSunsetTest.kt
+++ b/app/src/test/java/com/openlauncher/app/util/SunriseSunsetTest.kt
@@ -1,0 +1,31 @@
+package com.openlauncher.app.util
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SunriseSunsetTest {
+
+    // Singapore is near-equatorial, so sunrise/sunset barely drift across the
+    // year (observed on-device: 07:04 / 19:14) — a tolerant range is robust
+    // regardless of what real-world date this test runs on, since localMinutes()
+    // has no injectable date parameter (always Calendar.getInstance()).
+    @Test
+    fun `Singapore sunrise and sunset fall in the expected daily range`() {
+        val (riseMin, setMin) = SunriseSunset.localMinutes(1.35, 103.8)
+
+        val riseHour = riseMin / 60f
+        val setHour = setMin / 60f
+
+        assertTrue("sunrise $riseHour was outside 5:30-8:30", riseHour in 5.5f..8.5f)
+        assertTrue("sunset $setHour was outside 17:30-20:30", setHour in 17.5f..20.5f)
+        assertTrue("sunrise should be before sunset at the equator", riseMin < setMin)
+    }
+
+    @Test
+    fun `isDay agrees with the computed sunrise-sunset window`() {
+        val (riseMin, setMin) = SunriseSunset.localMinutes(1.35, 103.8)
+        val nowMin = java.util.Calendar.getInstance().let { it.get(java.util.Calendar.HOUR_OF_DAY) * 60 + it.get(java.util.Calendar.MINUTE) }
+        val expectedIsDay = nowMin in riseMin..setMin
+        assertTrue(SunriseSunset.isDay(1.35, 103.8) == expectedIsDay)
+    }
+}


### PR DESCRIPTION
## Summary

A few evenings' worth of dogfooding on a real head unit (Sinosmart TS18 platform, Android 13, Unisoc UIS8581A) turned into a batch of new widgets, a full theming system, and some polish/fixes to existing widgets. Opening this as one PR with a clean commit sequence rather than several interdependent smaller PRs — a few of the shared files (`HomeScreen.kt`, `AppSettings.kt`, `LauncherViewModel.kt`) have changes that genuinely depend on each other, and splitting them apart risked subtle breakage I couldn't fully re-verify without a second device. Happy to split anything out further if that's easier to review in pieces.

### New widgets
- **Fuel Log** — logs fill-ups (odometer, volume, cost), computes efficiency (L/100km or MPG) and cost/distance from consecutive entries. Uses manual odometer entry rather than GPS trip distance (Trip Tracker's distance is Compose-local state, not persisted — not a reliable distance source between fill-ups).
- **Quick Toggles** — WiFi panel, Bluetooth pairing screen, and DND toggle from the home grid. WiFi/Bluetooth open the OS's own settings UI rather than toggling directly, since apps can no longer flip those radios programmatically as of API 29+/31+.
- **Location** — live GPS coordinates + accuracy, with an honest "NO GPS FIX" state instead of faking data.
- **Reverse geocoding** (`NominatimApi.kt`) — free, no-API-key place name lookup (OpenStreetMap Nominatim, same no-signup spirit as the existing Open-Meteo weather call), shown in both Location and Weather widgets instead of raw coordinates.

### 8 dashboard themes (`ThemePresets.kt`)
Ignition, Amber Cluster, Cobalt Run, Verdigris, Plum Static, Blueprint, Circuit, Instrument Cluster. Each theme defines an independent accent/background/ink pairing *per mode* — `darkAccent/darkBg/darkInk` and `lightAccent/lightBg` are both hand-picked, not one color scheme with the other auto-derived — and every pairing was WCAG contrast-checked before landing. New "Dashboard Theme" picker in Settings.

When Display Mode is set to **Auto**, day/night isn't a fixed clock time — `SunriseSunset.isDay(lat, lon)` runs an actual solar-position calculation against the device's live GPS coordinates, rechecked every minute, and `resolveDashboardTheme()` swaps the active theme's day/night pair the moment that flips. (`Dark`/`Light` pin one manually; `System` instead follows Android's own dark-mode setting.)

### Widget polish
- **Clock** — was rendering almost empty (digits anchored bottom-left, rest of the tile blank). Added a greeting label + day/night icon up top.
- **Weather** — added a 6-hour forecast strip below current conditions.
- **Now Playing** — album art was a full-bleed cropped background across the whole tile. Changed to a centered, bounded thumbnail — closer to how Spotify's own player actually presents Canvas art.
- **Split Panel** layout preset — one-tap alternate grid arrangement, plus the underlying preset-switching system it's built on.

### Panel enrichment — Weather, Clock, Now Playing
More dogfooding, this time favoring folding new information into the three panels already in the Split Panel layout over growing the widget grid further. Each addition is independently toggleable from that widget's context menu:
- **Weather** — wind speed, "feels like" temperature, and per-hour rain chance in the forecast strip. All three were already coming back from the existing Open-Meteo call, just unused until now.
- **Clock** — sunrise/sunset times (reuses the `SunriseSunset` calc above, so no new cost) sitting above the time, and a compact WiFi/Bluetooth column in the panel's empty right side. Left DND out — not something anyone reaches for on a car head unit. Sunrise/sunset use 🌅/🌇 rather than generic arrows or Material Icons' single ambiguous "twilight" glyph (no distinct sunrise/sunset pair exists in Material Icons), matching the emoji already used for weather conditions elsewhere. Also added a 12/24-hour format toggle (defaults to 24-hour, matching prior behavior).
- **Now Playing** — a small source-app badge (the actual installed app's icon via `PackageManager`, not a hardcoded per-app icon) under the header, plus a Bluetooth glyph when audio is routed to a BT device (checked via `AudioManager#getDevices()`, which doesn't require `BLUETOOTH_CONNECT` — that permission is only needed to read a device's *name*). Useful mainly because source apps behave differently in the background (e.g. this unit's hardware radio app drops playback when backgrounded, Spotify doesn't).

### Bug fixes
- Clock and Location both render their own header text, but `HomeScreen`'s generic per-tile corner label was *also* rendering a label for those ids — same text shown twice, stacked. Fixed.
- `Sidebar.kt` read `settings.accentColor` and a hardcoded background directly, completely bypassing any theme — stayed visually stuck regardless of active theme or day/night mode. Now uses the same resolved theme `HomeScreen` uses.
- Several theme accents are intentionally dark even in *light* mode (e.g. Instrument Cluster's navy `#1F2A44`), but every selected `FilterChip` (Settings toggles, App Library filters) hardcoded a black label — dark text on a dark fill, effectively invisible on those themes. Added a shared `onAccentColor()` contrast helper, used wherever a chip fills with the theme accent.
- `LocationCompassManager` registered both the GPS and Network location providers simultaneously and accepted whichever one's callback fired most recently with no accuracy comparison at all. Network fixes (cell/WiFi) can be hundreds of meters coarser than GPS, so a good GPS fix would get overwritten by the next coarse Network update, then corrected again by the next GPS one — the displayed neighborhood name visibly jumped back and forth between two places every time the two providers alternated (reproduced live: bounced between two Singapore neighborhoods ~1km apart, repeatedly, over several minutes while driving). Added the standard Android `isBetterLocation` gate (prefers newer + more-accurate fixes, only lets a much less accurate fix through if the current one's gone stale) so a worse fix no longer overrides a better one. Confirmed stable on the next drive.
- The weather/place-name fetch throttle was stamped the moment a fetch was *attempted*, not when it succeeded — a single failure right after boot (before WiFi/cellular reconnects) would silently consume the whole throttle window, leaving the Weather panel empty for 30 minutes with no retry and no visible error. Now only stamped on success, so a failed attempt retries on the very next tick instead.
- Weather panel's place name was hard-truncated to one line with an ellipsis ("Singapore, Woodlands So…"). Now wraps to a 2nd line only when it doesn't fit on one.
- Clock panel's day/night icon was `SpaceBetween`'d across the full row width, so on a wider panel it drifted far from its "MORNING"/"EVENING" label into empty space. Anchored next to the label instead.

### Network dependency — Weather & Location
Both widgets go blank without internet: current conditions/forecast come from Open-Meteo, and the neighborhood-level place name (shown in both Weather and Location) comes from Nominatim reverse geocoding — neither has an offline fallback beyond holding the last successfully fetched value in memory for the rest of the session. Every other widget in this PR works from local sensors/data only. Flagged this directly in the Widget Library picker (edit mode) with an amber WiFi badge + "NEEDS DATA" label on those two cards, since edit mode otherwise renders every widget in flat grey with no way to tell them apart at a glance.

### Experimental: header voltage reading
Reads the standard `BatteryManager` voltage field next to the WiFi icon — several aftermarket units have no real internal battery and wire the car's 12V input straight into that field. Guarded to hide rather than show a false `0.0V` when the value's implausibly low for a running vehicle. Confirmed this field is **not** wired to the real sensor on the TS18 unit I tested on (its own status bar almost certainly reads voltage via CAN bus/vendor MCU instead, consistent with how its radio integration works, and that's not reachable through any public Android API). Whether this works is unit/ROM-dependent — reasonable to attempt with a safe fallback, not a guaranteed-working feature. Happy to drop this one if it's not wanted given the uncertainty.

## Test plan
- [x] Built and installed on one physical unit (Sinosmart TS18, Android 13) across several sessions; every feature above confirmed working live *except* the voltage reading (noted above) and the Bluetooth-audio-route glyph (added most recently — logic is straightforward but I haven't yet confirmed on-device that it only lights up when actually routed over BT vs. wired/speaker)
- [x] Added a JVM unit test suite (`./gradlew testDebugUnitTest`, 15 tests) covering the pure-logic functions — `isBetterLocation`, `SunriseSunset`, `resolveDashboardTheme`, `computeWidgetMove`. No device/emulator needed; runs in CI if this repo ever adds one.
- [ ] Not tested on other hardware — the pre-existing szchoiceway-specific radio path is untouched, but I can't personally verify it since my unit doesn't use that platform
- [ ] No automated tests added (repo doesn't appear to have a test suite currently)

Let me know if you'd like anything restructured, split up, or dropped — glad to iterate.


